### PR TITLE
BUG: Silence yaml.load() warning

### DIFF
--- a/qtpyvcp/vcp_chooser/vcp_chooser.py
+++ b/qtpyvcp/vcp_chooser/vcp_chooser.py
@@ -89,7 +89,7 @@ class VCPChooser(QDialog):
                     continue
                 clean.append(line)
 
-            config = yaml.load(''.join(clean))
+            config = yaml.load(''.join(clean), Loader=yaml.SafeLoader)
             if config is not None:
                 vcp_data.update(config.get('vcp', {}))
             vcp_name = vcp_data.get('name', entry_point.name)


### PR DESCRIPTION
This fixes issue #7 where yaml.load issues the following warning:

92: YAMLLoadWarning: calling yaml.load() without Loader=... is
deprecated, as the default Loader is unsafe. Please read
msg.pyyaml.org/load for full details.

Ref:
https://github.com/yaml/pyyaml/wiki/PyYAML-yaml.load(input)-Deprecation