### PR TITLE
BUG: The close menu item uses a hardcoded path

### DIFF
--- a/examples/probe_basic/menubar.yml
+++ b/examples/probe_basic/menubar.yml
@@ -14,7 +14,7 @@ menubar:
       action:
 
     - title: "&Close"
-      action: program.load:/home/kurt/dev/cnc/qtpyvcp/sim/example_gcode/blank.ngc
+      action: program.clear
 
     - title: "Save &As"
       action:

--- a/examples/probe_basic_latc/menubar.yml
+++ b/examples/probe_basic_latc/menubar.yml
@@ -14,7 +14,7 @@ menubar:
       action:
 
     - title: "&Close"
-      action: program.load:/home/kurt/dev/cnc/qtpyvcp/sim/example_gcode/blank.ngc
+      action: program.clear
 
     - title: "Save &As"
       action:

--- a/examples/probe_basic_lathe/menubar.yml
+++ b/examples/probe_basic_lathe/menubar.yml
@@ -14,7 +14,7 @@ menubar:
       action:
 
     - title: "&Close"
-      action: program.load:/home/kurt/dev/cnc/qtpyvcp/sim/example_gcode/blank.ngc
+      action: program.clear
 
     - title: "Save &As"
       action:

--- a/examples/probe_basic_vertical/menubar.yml
+++ b/examples/probe_basic_vertical/menubar.yml
@@ -14,7 +14,7 @@ menubar:
       action:
 
     - title: "&Close"
-      action: program.load:/home/kurt/dev/cnc/qtpyvcp/sim/example_gcode/blank.ngc
+      action: program.clear
 
     - title: "Save &As"
       action:

--- a/qtpyvcp/actions/program_actions.py
+++ b/qtpyvcp/actions/program_actions.py
@@ -1,5 +1,6 @@
 import sys
 import linuxcnc
+import tempfile
 
 # Set up logging
 from qtpyvcp.utilities import logger
@@ -38,6 +39,16 @@ load.bindOk = lambda *args, **kwargs: True
 
 def reload():
     LOG.error('Reload not implemented yet.')
+
+def clear():
+    """Clear the loaded NC program."""
+    _, blankfile = tempfile.mkstemp(prefix="blank", suffix="ngc")
+    with open(blankfile, 'w') as fp:
+        fp.write("(New Program)\n\n\nM30")
+    load(blankfile, add_to_recents=False)
+
+clear.ok = lambda *args, **kwargs: True
+clear.bindOk = lambda *args, **kwargs: True
 
 def addToRecents(fname):
     files = STATUS.recent_files.getValue()

--- a/qtpyvcp/yaml_lib/default_menubar.yml
+++ b/qtpyvcp/yaml_lib/default_menubar.yml
@@ -14,7 +14,7 @@ default_menubar:
       action:
 
     - title: "&Close"
-      action: program.load:/home/kurt/dev/cnc/qtpyvcp/sim/example_gcode/blank.ngc
+      action: program.clear
 
     - title: "Save &As"
       action:

--- a/sim/example_gcode/blank.ngc
+++ b/sim/example_gcode/blank.ngc
@@ -1,4 +1,0 @@
-(New Program)
-
-
-M30


### PR DESCRIPTION
This doesn't work for installs where
/home/kurt/dev/cnc/qtpyvcp/sim/example_gcode/blank.ngc
does not exist.

This commit changes to a temporary generated file.