### PR TITLE
Mdi history and queue widget

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,6 @@ linuxcnc/configs/**/*.old
 # persistent data files 
 linuxcnc/configs/**/.*.json
 linuxcnc/configs/**/.*.pickle
+qtpyvcp/.settings/
+qtpyvcp/.pydevproject
+qtpyvcp/.project

--- a/qtpyvcp/__init__.py
+++ b/qtpyvcp/__init__.py
@@ -1,4 +1,5 @@
-import os
+#import sys;sys.path.append(r'/root/.p2/pool/plugins/org.python.pydev.core_7.5.0.202001101138/pysrc')
+#import pydevd;pydevd.settrace()
 
 import os
 from collections import OrderedDict

--- a/qtpyvcp/plugins/status.py
+++ b/qtpyvcp/plugins/status.py
@@ -141,6 +141,14 @@ class Status(DataPlugin):
 
         chan.signal.emit(chan.value)
 
+    def mdi_remove_entry(self, mdi_index):
+        """Remove the indicated cmd by index reference"""
+        # TODO: This has some potential code redundancy. Follow above pattern
+        chan = self.mdi_history
+        cmds = chan.value
+        del cmds[mdi_index]
+        chan.signal.emit(cmds)
+
     @DataChannel
     def on(self, chan):
         """True if machine power is ON."""

--- a/qtpyvcp/plugins/status.py
+++ b/qtpyvcp/plugins/status.py
@@ -119,7 +119,9 @@ class Status(DataPlugin):
             When the list exceeds the length given by MAX_MDI_COMMANDS the
             oldest entries will be dropped.
 
-            Duplicate commands will be removed, so the most recently issued
+            Duplicate commands will not be removed, so that MDI History
+            can be replayed via the queue meachanisim from a point in
+            the history forward. The most recently issued
             command will always be at the front of the list.
         """
         return chan.value

--- a/qtpyvcp/plugins/status.py
+++ b/qtpyvcp/plugins/status.py
@@ -129,10 +129,10 @@ class Status(DataPlugin):
         if isinstance(new_value, list):
             chan.value = new_value[:self._max_mdi_history_length]
         else:
-            cmd = str(new_value.strip())
+            #cmd = str(new_value.strip())
             cmds = chan.value
-            if cmd in cmds:
-                cmds.remove(cmd)
+            #if cmd in cmds:
+            #    cmds.remove(cmd)
 
             cmds.insert(0, new_value)
             chan.value = cmds[:self._max_mdi_history_length]

--- a/qtpyvcp/widgets/input_widgets/designer_plugins.py
+++ b/qtpyvcp/widgets/input_widgets/designer_plugins.py
@@ -13,6 +13,11 @@ class MDIEntryPlugin(_DesignerPlugin):
     def toolTip(self):
         return "MDI command entry"
 
+from mdihistory_widget import MDIHistory
+class MDIHistoryPlugin(_DesignerPlugin):
+    def pluginClass(self):
+        return MDIHistory
+
 from gcode_editor import GcodeEditor
 class GcodeEditorPlugin(_DesignerPlugin):
     def pluginClass(self):

--- a/qtpyvcp/widgets/input_widgets/mdientry_widget.py
+++ b/qtpyvcp/widgets/input_widgets/mdientry_widget.py
@@ -1,7 +1,7 @@
 
 from qtpy.QtCore import Qt, Slot, Property, QStringListModel
 from qtpy.QtGui import QValidator
-from qtpy.QtWidgets import QLineEdit, QCompleter
+from qtpy.QtWidgets import QLineEdit, QListWidgetItem, QCompleter
 
 from qtpyvcp.plugins import getPlugin
 from qtpyvcp.utilities.info import Info
@@ -52,6 +52,11 @@ class MDIEntry(QLineEdit, CMDWidget):
         issue_mdi(cmd)
         self.setText('')
         STATUS.mdi_history.setValue(cmd)
+
+    @Slot(QListWidgetItem)
+    def setMDIText(self, listItem):
+        if listItem is not None:
+            self.setText(listItem.text())
 
     def keyPressEvent(self, event):
         if event.key() == Qt.Key_Up or event.key() == Qt.Key_Down:

--- a/qtpyvcp/widgets/input_widgets/mdihistory_widget.py
+++ b/qtpyvcp/widgets/input_widgets/mdihistory_widget.py
@@ -1,0 +1,57 @@
+
+from qtpy.QtCore import Qt, Slot, Property
+from qtpy.QtGui import QValidator
+from qtpy.QtWidgets import QListWidget, QListWidgetItem
+
+from qtpyvcp.plugins import getPlugin
+from qtpyvcp.utilities.info import Info
+from qtpyvcp.actions.machine_actions import issue_mdi
+from qtpyvcp.widgets.base_widgets.base_widget import CMDWidget
+
+STATUS = getPlugin('status')
+INFO = Info()
+
+
+
+class MDIHistory(QListWidget, CMDWidget):
+    """MDI History
+
+    Xxxxxx.
+    """
+    def __init__(self, parent=None):
+        super(MDIHistory, self).__init__(parent)
+
+        #self.returnPressed.connect(self.submit)
+
+
+    @Slot()
+    def submit(self):
+        cmd = str(self.text()).strip()
+        issue_mdi(cmd)
+        self.setText('')
+        STATUS.mdi_history.setValue(cmd)
+
+    def rowClicked(self):
+        print('item clicked in list: {}'.format(self.currentItem().text()))
+
+    def keyPressEvent(self, event):
+        if event.key() == Qt.Key_Up or event.key() == Qt.Key_Down:
+            pass
+        else:
+            super(MDIHistory, self).keyPressEvent(event)
+
+    def focusInEvent(self, event):
+        super(MDIHistory, self).focusInEvent(event)
+        pass
+
+    def setHistory(self, stringList):
+        print('Clear and load history to list')
+
+    def initialize(self):
+        history = STATUS.mdi_history.value
+        self.addItems(history)
+        self.clicked.connect(self.rowClicked)
+        STATUS.mdi_history.notify(self.setHistory)
+
+    def terminate(self):
+        pass

--- a/qtpyvcp/widgets/input_widgets/mdihistory_widget.py
+++ b/qtpyvcp/widgets/input_widgets/mdihistory_widget.py
@@ -90,6 +90,20 @@ class MDIHistory(QListWidget, CMDWidget):
             self.heart_beat_timer.start()
 
     @Slot()
+    def clear_queue(self):
+        """Clear queue items yet to be run."""
+        list_length = self.count()-1
+        while list_length >= 0:
+            row_item = self.item(list_length)
+            row_item_data = row_item.data(MDIHistory.MDQQ_ROLE)
+
+            if row_item_data == MDIHistory.MDIQ_TODO:
+                row_item.setData(MDIHistory.MDQQ_ROLE, MDIHistory.MDIQ_DONE)
+                row_item.setIcon(QIcon())
+
+            list_length -= 1
+
+    @Slot()
     def run_from_selection(self):
         """Start running MDI from the selected row back to top."""
         row = self.currentRow()
@@ -156,7 +170,6 @@ class MDIHistory(QListWidget, CMDWidget):
             row_item.setIcon(QIcon())
             self.addItem(row_item)
 
-
     def heart_beat(self):
         """Supports heart beat on the MDI History execution queue.
         Issue the next command from the queue.
@@ -206,7 +219,6 @@ class MDIHistory(QListWidget, CMDWidget):
         # use a 1 second timer
         self.heart_beat_timer.start(1000)
         self.heart_beat_timer.timeout.connect(self.heart_beat)
-
 
     def terminate(self):
         """Teardown processing."""

--- a/qtpyvcp/widgets/input_widgets/mdihistory_widget.py
+++ b/qtpyvcp/widgets/input_widgets/mdihistory_widget.py
@@ -104,7 +104,7 @@ class MDIHistory(QListWidget, CMDWidget):
             list_length -= 1
 
     @Slot()
-    def clear_selection(self):
+    def clearSelection(self):
         """Remove the selected line"""
         row = self.currentRow()
         self.takeItem(row)

--- a/qtpyvcp/widgets/input_widgets/mdihistory_widget.py
+++ b/qtpyvcp/widgets/input_widgets/mdihistory_widget.py
@@ -70,17 +70,17 @@ class MDIHistory(QListWidget, CMDWidget):
         #self.returnPressed.connect(self.submit)
 
     @Property(str)
-    def MDIEntryName(self):
+    def mdiEntrylineName(self):
         """Return name of entry object to Designer"""
-        return self._mdi_entryline_name
+        return self.mdi_entryline_name
 
-    @mdi_entryline_name.setter
-    def mdi_entryline_name(self, object_name):
+    @mdiEntrylineName.setter
+    def mdiEntrylineName(self, object_name):
         """Set the name for Designer"""
-        self._mdi_entryline_name = object_name
+        self.mdi_entryline_name = object_name
 
     @Slot(bool)
-    def toggle_queue(self, toggle):
+    def toggleQueue(self, toggle):
         """Toggle queue pause.
         Starting point is the queue is active.
         """
@@ -186,7 +186,7 @@ class MDIHistory(QListWidget, CMDWidget):
             row_item.setIcon(QIcon())
             self.addItem(row_item)
 
-    def heart_beat(self):
+    def heartBeat(self):
         """Supports heart beat on the MDI History execution queue.
         Issue the next command from the queue.
         Double check machine is in ok state to accept next command.
@@ -234,7 +234,7 @@ class MDIHistory(QListWidget, CMDWidget):
         self.heart_beat_timer = QTimer(self)
         # use a 1 second timer
         self.heart_beat_timer.start(1000)
-        self.heart_beat_timer.timeout.connect(self.heart_beat)
+        self.heart_beat_timer.timeout.connect(self.heartBeat)
 
     def terminate(self):
         """Teardown processing."""

--- a/qtpyvcp/widgets/input_widgets/mdihistory_widget.py
+++ b/qtpyvcp/widgets/input_widgets/mdihistory_widget.py
@@ -122,7 +122,7 @@ class MDIHistory(QListWidget, CMDWidget):
             row -= 1
 
     @Slot()
-    def run_selection(self):
+    def runSelection(self):
         """Run the selected row only."""
         row = self.currentRow()
         # from selected row loop back to top and set ready for run

--- a/qtpyvcp/widgets/input_widgets/mdihistory_widget.py
+++ b/qtpyvcp/widgets/input_widgets/mdihistory_widget.py
@@ -115,6 +115,15 @@ class MDIHistory(QListWidget, CMDWidget):
             row -= 1
 
     @Slot()
+    def run_selection(self):
+        """Run the selected row only."""
+        row = self.currentRow()
+        # from selected row loop back to top and set ready for run
+        row_item = self.item(row)
+        row_item.setData(MDIHistory.MDQQ_ROLE, MDIHistory.MDIQ_TODO)
+        row_item.setIcon(self.icon_waiting)
+
+    @Slot()
     def submit(self):
         """Put a new command on the queue for later execution.
         """

--- a/qtpyvcp/widgets/input_widgets/mdihistory_widget.py
+++ b/qtpyvcp/widgets/input_widgets/mdihistory_widget.py
@@ -37,7 +37,6 @@ STAT = STATUS.stat
 INFO = Info()
 
 
-
 class MDIHistory(QListWidget, CMDWidget):
     """MDI History and Queuing Widget.
 
@@ -61,7 +60,9 @@ class MDIHistory(QListWidget, CMDWidget):
         self.mdi_entry_widget = None
         self.heart_beat_timer = None
         self.icon_run_name = 'media-playback-start'
+        self.icon_run = QIcon.fromTheme(self.icon_run_name)
         self.icon_waiting_name = 'media-playback-pause'
+        self.icon_waiting = QIcon.fromTheme(self.icon_waiting_name)
 
         #self.returnPressed.connect(self.submit)
 
@@ -86,6 +87,17 @@ class MDIHistory(QListWidget, CMDWidget):
             self.heart_beat_timer.start()
 
     @Slot()
+    def run_from_selection(self):
+        """Start running MDI from the selected row back to top."""
+        row = self.currentRow() - 1
+        # from selected row loop back to top and set ready for run
+        while row >= 0:
+            row_item = self.item(row)
+            row_item.setData(MDIHistory.MDQQ_ROLE, MDIHistory.MDIQ_TODO)
+            row_item.setIcon(self.icon_waiting)
+            row -= 1
+
+    @Slot()
     def submit(self):
         """Issue the next command from the queue.
         Double check machine is in ok state to accept next command.
@@ -97,7 +109,7 @@ class MDIHistory(QListWidget, CMDWidget):
         row_item = QListWidgetItem()
         row_item.setText(cmd)
         row_item.setData(MDIHistory.MDQQ_ROLE, MDIHistory.MDIQ_TODO)
-        row_item.setIcon(QIcon.fromTheme(self.icon_waiting_name))
+        row_item.setIcon(self.icon_waiting)
         self.insertItem(0, row_item)
 
         # now clear down the mdi entry text ready for new input
@@ -165,7 +177,7 @@ class MDIHistory(QListWidget, CMDWidget):
             elif row_item_data == MDIHistory.MDIQ_TODO:
                 cmd = str(row_item.text()).strip()
                 row_item.setData(MDIHistory.MDQQ_ROLE, MDIHistory.MDIQ_RUNNING)
-                row_item.setIcon(QIcon.fromTheme(self.icon_run_name))
+                row_item.setIcon(self.icon_run)
                 print "Item found to execute on: {}".format(cmd)
                 issue_mdi(cmd)
                 break

--- a/qtpyvcp/widgets/input_widgets/mdihistory_widget.py
+++ b/qtpyvcp/widgets/input_widgets/mdihistory_widget.py
@@ -229,7 +229,7 @@ class MDIHistory(QListWidget, CMDWidget):
         for win_name, obj in qtpyvcp.WINDOWS.items():
             if hasattr(obj, self.mdi_entryline_name):
                 self.mdi_entry_widget = getattr(obj, self.mdi_entryline_name)
-
+                break
         # Setup the basic timer system as a heart beat on the queue
         self.heart_beat_timer = QTimer(self)
         # use a 1 second timer

--- a/qtpyvcp/widgets/input_widgets/mdihistory_widget.py
+++ b/qtpyvcp/widgets/input_widgets/mdihistory_widget.py
@@ -90,7 +90,7 @@ class MDIHistory(QListWidget, CMDWidget):
             self.heart_beat_timer.start()
 
     @Slot()
-    def clear_queue(self):
+    def clearQueue(self):
         """Clear queue items yet to be run."""
         list_length = self.count()-1
         while list_length >= 0:

--- a/qtpyvcp/widgets/input_widgets/mdihistory_widget.py
+++ b/qtpyvcp/widgets/input_widgets/mdihistory_widget.py
@@ -104,6 +104,13 @@ class MDIHistory(QListWidget, CMDWidget):
             list_length -= 1
 
     @Slot()
+    def clear_selection(self):
+        """Remove the selected line"""
+        row = self.currentRow()
+        self.takeItem(row)
+        STATUS.mdi_remove_entry(row)
+
+    @Slot()
     def run_from_selection(self):
         """Start running MDI from the selected row back to top."""
         row = self.currentRow()

--- a/qtpyvcp/widgets/input_widgets/mdihistory_widget.py
+++ b/qtpyvcp/widgets/input_widgets/mdihistory_widget.py
@@ -104,7 +104,7 @@ class MDIHistory(QListWidget, CMDWidget):
             list_length -= 1
 
     @Slot()
-    def clearSelection(self):
+    def removeSelectedItem(self):
         """Remove the selected line"""
         row = self.currentRow()
         self.takeItem(row)
@@ -221,8 +221,8 @@ class MDIHistory(QListWidget, CMDWidget):
     def initialize(self):
         """Load up starting data and set signal connections."""
         history = STATUS.mdi_history.value
-        self.set_history(history)
-        self.clicked.connect(self.row_clicked)
+        self.setHistory(history)
+        self.clicked.connect(self.rowClicked)
 
         # Get handle to windows list and seach through them
         # for the widget referenced in mdi_entryline_name

--- a/qtpyvcp/widgets/input_widgets/mdihistory_widget.py
+++ b/qtpyvcp/widgets/input_widgets/mdihistory_widget.py
@@ -174,7 +174,7 @@ class MDIHistory(QListWidget, CMDWidget):
     #    super(MDIHistory, self).focusInEvent(event)
     #    pass
 
-    def set_history(self, items_list):
+    def setHistory(self, items_list):
         """Clear and reset the history in the list.
         item_list is a list of strings."""
         print 'Clear and load history to list'

--- a/qtpyvcp/widgets/input_widgets/mdihistory_widget.py
+++ b/qtpyvcp/widgets/input_widgets/mdihistory_widget.py
@@ -148,7 +148,7 @@ class MDIHistory(QListWidget, CMDWidget):
         # now clear down the mdi entry text ready for new input
         self.mdi_entry_widget.clear()
 
-    def row_clicked(self):
+    def rowClicked(self):
         """Item row clicked."""
         pass
 

--- a/qtpyvcp/widgets/input_widgets/mdihistory_widget.py
+++ b/qtpyvcp/widgets/input_widgets/mdihistory_widget.py
@@ -152,7 +152,7 @@ class MDIHistory(QListWidget, CMDWidget):
         """Item row clicked."""
         pass
 
-    def key_press_event(self, event):
+    def keyPressEvent(self, event):
         """Key movement processing.
         Arrow keys move the selected list item up/down
         Return key generates a submit situation by making the item as

--- a/qtpyvcp/widgets/input_widgets/mdihistory_widget.py
+++ b/qtpyvcp/widgets/input_widgets/mdihistory_widget.py
@@ -111,7 +111,7 @@ class MDIHistory(QListWidget, CMDWidget):
         STATUS.mdi_remove_entry(row)
 
     @Slot()
-    def run_from_selection(self):
+    def runFromSelection(self):
         """Start running MDI from the selected row back to top."""
         row = self.currentRow()
         # from selected row loop back to top and set ready for run

--- a/qtpyvcp/widgets/input_widgets/mdihistory_widget.py
+++ b/qtpyvcp/widgets/input_widgets/mdihistory_widget.py
@@ -19,6 +19,7 @@ ToDo:
 """
 
 from qtpy.QtCore import Qt, Slot, Property, QTimer
+from qtpy.QtGui import QIcon
 from qtpy.QtWidgets import QListWidget
 from qtpy.QtWidgets import QListWidgetItem
 
@@ -59,6 +60,8 @@ class MDIHistory(QListWidget, CMDWidget):
         self.mdi_entryline_name = None
         self.mdi_entry_widget = None
         self.heart_beat_timer = None
+        self.icon_run_name = 'media-playback-start'
+        self.icon_waiting_name = 'media-playback-pause'
 
         #self.returnPressed.connect(self.submit)
 
@@ -72,6 +75,16 @@ class MDIHistory(QListWidget, CMDWidget):
         """Set the name for Designer"""
         self._mdi_entryline_name = object_name
 
+    @Slot(bool)
+    def toggle_queue(self, toggle):
+        """Toggle queue pause.
+        Starting point is the queue is active.
+        """
+        if toggle:
+            self.heart_beat_timer.stop()
+        else:
+            self.heart_beat_timer.start()
+
     @Slot()
     def submit(self):
         """Issue the next command from the queue.
@@ -84,6 +97,7 @@ class MDIHistory(QListWidget, CMDWidget):
         row_item = QListWidgetItem()
         row_item.setText(cmd)
         row_item.setData(MDIHistory.MDQQ_ROLE, MDIHistory.MDIQ_TODO)
+        row_item.setIcon(QIcon.fromTheme(self.icon_waiting_name))
         self.insertItem(0, row_item)
 
         # now clear down the mdi entry text ready for new input
@@ -124,6 +138,7 @@ class MDIHistory(QListWidget, CMDWidget):
             row_item = QListWidgetItem()
             row_item.setText(item)
             row_item.setData(MDIHistory.MDQQ_ROLE, MDIHistory.MDIQ_DONE)
+            row_item.setIcon(QIcon())
             self.addItem(row_item)
 
 
@@ -144,10 +159,13 @@ class MDIHistory(QListWidget, CMDWidget):
             if row_item_data == MDIHistory.MDIQ_RUNNING:
                 # machine is in idle state so the running command is done
                 row_item.setData(MDIHistory.MDQQ_ROLE, MDIHistory.MDIQ_DONE)
+                row_item.setIcon(QIcon())
+
 
             elif row_item_data == MDIHistory.MDIQ_TODO:
                 cmd = str(row_item.text()).strip()
                 row_item.setData(MDIHistory.MDQQ_ROLE, MDIHistory.MDIQ_RUNNING)
+                row_item.setIcon(QIcon.fromTheme(self.icon_run_name))
                 print "Item found to execute on: {}".format(cmd)
                 issue_mdi(cmd)
                 break

--- a/qtpyvcp/widgets/input_widgets/mdihistory_widget.py
+++ b/qtpyvcp/widgets/input_widgets/mdihistory_widget.py
@@ -1,20 +1,38 @@
-"""MDI History Widget
-Maintains MDI history and implements a queue system to support
-entering in new MDI commands while others are being executed.
+# -*- coding: utf-8 -*-
+"""QtPyVCP MDI History Widget
+
+This widget implements the following key elements:
+[1] A history display of MDI commands issued with the latest
+command at the top of the list and the oldest at the bottom
+of the list.
+
+[2] A queue system of commands that have been entered
+but have not yet been executed. This allows the rapid entry
+of MDI commands to be executed without having to wait for any
+running commands to complete.
+
+ToDo:
+    * add/test for styling based on the class queue codes
+    * be able to select and remove unwanted commands from the history
+    * be able to select a row and run commands from that point upwards
+
 """
-from qtpy.QtCore import Qt, Slot, Property
-#from qtpy.QtGui import QValidator
+
+from qtpy.QtCore import Qt, Slot, Property, QTimer
 from qtpy.QtWidgets import QListWidget
 from qtpy.QtWidgets import QListWidgetItem
 
+import qtpyvcp
 from qtpyvcp.plugins import getPlugin
 from qtpyvcp.utilities.info import Info
 from qtpyvcp.actions.machine_actions import issue_mdi
 from qtpyvcp.widgets.base_widgets.base_widget import CMDWidget
-from qtpyvcp.widgets.input_widgets.mdientry_widget import MDIEntry
+
+import linuxcnc
 
 
 STATUS = getPlugin('status')
+STAT = STATUS.stat
 INFO = Info()
 
 
@@ -28,6 +46,8 @@ class MDIHistory(QListWidget, CMDWidget):
     Visual style is used to identify items that have been completed,
     are running and are yet to run.
     """
+
+    # MDI Queue status constants
     MDIQ_DONE = 0
     MDIQ_RUNNING = 1
     MDIQ_TODO = 2
@@ -36,10 +56,9 @@ class MDIHistory(QListWidget, CMDWidget):
     def __init__(self, parent=None):
         super(MDIHistory, self).__init__(parent)
 
-        print 'init parent = {}'.format(parent)
-
         self.mdi_entryline_name = None
         self.mdi_entry_widget = None
+        self.heart_beat_timer = None
 
         #self.returnPressed.connect(self.submit)
 
@@ -67,19 +86,8 @@ class MDIHistory(QListWidget, CMDWidget):
         row_item.setData(MDIHistory.MDQQ_ROLE, MDIHistory.MDIQ_TODO)
         self.insertItem(0, row_item)
 
-        # scan for the next command to execute from bottom up.
-        list_length = self.count()-1
-        while list_length >= 0:
-            row_item = self.item(list_length)
-            row_item_data = row_item.data(MDIHistory.MDQQ_ROLE)
-            if row_item_data == MDIHistory.MDIQ_TODO:
-                print "Item found to execute on: {}".format(row_item.text())
-                break
-            list_length -= 1
-
-
-        #issue_mdi(cmd)
-        #STATUS.mdi_history.setValue(cmd)
+        # now clear down the mdi entry text ready for new input
+        self.mdi_entry_widget.clear()
 
     def row_clicked(self):
         """Item row clicked."""
@@ -119,18 +127,51 @@ class MDIHistory(QListWidget, CMDWidget):
             self.addItem(row_item)
 
 
-        #self.addItems(history_list)
+    def heart_beat(self):
+        """Supports heart beat on the MDI History execution queue."""
+        # check if machine is idle and ready to run another command
+        if STAT.interp_state != linuxcnc.INTERP_IDLE:
+            # RS274NGC interpreter not in a state to execute
+            print
+            return
+
+        # scan for the next command to execute from bottom up.
+        list_length = self.count()-1
+        while list_length >= 0:
+            row_item = self.item(list_length)
+            row_item_data = row_item.data(MDIHistory.MDQQ_ROLE)
+
+            if row_item_data == MDIHistory.MDIQ_RUNNING:
+                # machine is in idle state so the running command is done
+                row_item.setData(MDIHistory.MDQQ_ROLE, MDIHistory.MDIQ_DONE)
+
+            elif row_item_data == MDIHistory.MDIQ_TODO:
+                cmd = str(row_item.text()).strip()
+                row_item.setData(MDIHistory.MDQQ_ROLE, MDIHistory.MDIQ_RUNNING)
+                print "Item found to execute on: {}".format(cmd)
+                issue_mdi(cmd)
+                break
+
+            list_length -= 1
 
     def initialize(self):
         """Load up starting data and set signal connections."""
         history = STATUS.mdi_history.value
         self.set_history(history)
         self.clicked.connect(self.row_clicked)
-        #STATUS.mdi_history.notify(self.set_history)
-        self.mdi_entry_widget = self.parent().findChild(MDIEntry, self.mdi_entryline_name)
-        #print 'find child: {}'.format(self.parent().findChild(MDIEntry, 'mdiEntry'))
+
+        # get handle to windows list and seach through them
+        # for the widget referenced in mdi_entryline_name
+        for win_name, obj in qtpyvcp.WINDOWS.items():
+            if hasattr(obj, self.mdi_entryline_name):
+                self.mdi_entry_widget = getattr(obj, self.mdi_entryline_name)
+
+        # setup the basic timer system as a heart beat on the queue
+        self.heart_beat_timer = QTimer(self)
+        self.heart_beat_timer.start(1000)
+        self.heart_beat_timer.timeout.connect(self.heart_beat)
 
 
     def terminate(self):
         """Teardown processing."""
-        pass
+        self.heart_beat_timer.stop()

--- a/qtpyvcp/widgets/input_widgets/mdihistory_widget.py
+++ b/qtpyvcp/widgets/input_widgets/mdihistory_widget.py
@@ -70,7 +70,7 @@ class MDIHistory(QListWidget, CMDWidget):
         #self.returnPressed.connect(self.submit)
 
     @Property(str)
-    def mdi_entryline_name(self):
+    def MDIEntryName(self):
         """Return name of entry object to Designer"""
         return self._mdi_entryline_name
 

--- a/qtpyvcp/widgets/input_widgets/mdihistory_widget.py
+++ b/qtpyvcp/widgets/input_widgets/mdihistory_widget.py
@@ -24,34 +24,48 @@ class MDIHistory(QListWidget, CMDWidget):
         #self.returnPressed.connect(self.submit)
 
 
-    @Slot()
     def submit(self):
         cmd = str(self.text()).strip()
         issue_mdi(cmd)
-        self.setText('')
         STATUS.mdi_history.setValue(cmd)
+
 
     def rowClicked(self):
         print('item clicked in list: {}'.format(self.currentItem().text()))
 
+
     def keyPressEvent(self, event):
-        if event.key() == Qt.Key_Up or event.key() == Qt.Key_Down:
-            pass
+        row = self.currentRow()
+        if event.key() == Qt.Key_Up:
+            if row > 0:
+                row -= 1
+        elif event.key() == Qt.Key_Down:
+            if row < self.count()-1:
+                row += 1
         else:
             super(MDIHistory, self).keyPressEvent(event)
+
+        self.setCurrentRow(row)
+
 
     def focusInEvent(self, event):
         super(MDIHistory, self).focusInEvent(event)
         pass
 
+
     def setHistory(self, stringList):
         print('Clear and load history to list')
+        self.clear()
+        self.addItems(stringList)
+
+
 
     def initialize(self):
         history = STATUS.mdi_history.value
         self.addItems(history)
         self.clicked.connect(self.rowClicked)
         STATUS.mdi_history.notify(self.setHistory)
+
 
     def terminate(self):
         pass

--- a/qtpyvcp/widgets/input_widgets/mdihistory_widget.py
+++ b/qtpyvcp/widgets/input_widgets/mdihistory_widget.py
@@ -1,12 +1,18 @@
-
+"""MDI History Widget
+Maintains MDI history and implements a queue system to support
+entering in new MDI commands while others are being executed.
+"""
 from qtpy.QtCore import Qt, Slot, Property
-from qtpy.QtGui import QValidator
-from qtpy.QtWidgets import QListWidget, QListWidgetItem
+#from qtpy.QtGui import QValidator
+from qtpy.QtWidgets import QListWidget
+from qtpy.QtWidgets import QListWidgetItem
 
 from qtpyvcp.plugins import getPlugin
 from qtpyvcp.utilities.info import Info
 from qtpyvcp.actions.machine_actions import issue_mdi
 from qtpyvcp.widgets.base_widgets.base_widget import CMDWidget
+from qtpyvcp.widgets.input_widgets.mdientry_widget import MDIEntry
+
 
 STATUS = getPlugin('status')
 INFO = Info()
@@ -14,27 +20,77 @@ INFO = Info()
 
 
 class MDIHistory(QListWidget, CMDWidget):
-    """MDI History
+    """MDI History and Queuing Widget.
 
-    Xxxxxx.
+    This widget implements a visual view of the MDI command
+    history.  It also implements a command queuing startegy
+    so that commands can be entered and queued up for execution.
+    Visual style is used to identify items that have been completed,
+    are running and are yet to run.
     """
+    MDIQ_DONE = 0
+    MDIQ_RUNNING = 1
+    MDIQ_TODO = 2
+    MDQQ_ROLE = 256
+
     def __init__(self, parent=None):
         super(MDIHistory, self).__init__(parent)
 
+        print 'init parent = {}'.format(parent)
+
+        self.mdi_entryline_name = None
+        self.mdi_entry_widget = None
+
         #self.returnPressed.connect(self.submit)
 
+    @Property(str)
+    def mdi_entryline_name(self):
+        """Return name of entry object to Designer"""
+        return self._mdi_entryline_name
 
+    @mdi_entryline_name.setter
+    def mdi_entryline_name(self, object_name):
+        """Set the name for Designer"""
+        self._mdi_entryline_name = object_name
+
+    @Slot()
     def submit(self):
-        cmd = str(self.text()).strip()
-        issue_mdi(cmd)
-        STATUS.mdi_history.setValue(cmd)
+        """Issue the next command from the queue.
+        Double check machine is in ok state to accept next command.
+        Issue the command and if success mark command as being active.
+        Mark last command as done.
+        """
+        # put the new command on the queue
+        cmd = str(self.mdi_entry_widget.text()).strip()
+        row_item = QListWidgetItem()
+        row_item.setText(cmd)
+        row_item.setData(MDIHistory.MDQQ_ROLE, MDIHistory.MDIQ_TODO)
+        self.insertItem(0, row_item)
+
+        # scan for the next command to execute from bottom up.
+        list_length = self.count()-1
+        while list_length >= 0:
+            row_item = self.item(list_length)
+            row_item_data = row_item.data(MDIHistory.MDQQ_ROLE)
+            if row_item_data == MDIHistory.MDIQ_TODO:
+                print "Item found to execute on: {}".format(row_item.text())
+                break
+            list_length -= 1
 
 
-    def rowClicked(self):
-        print('item clicked in list: {}'.format(self.currentItem().text()))
+        #issue_mdi(cmd)
+        #STATUS.mdi_history.setValue(cmd)
 
+    def row_clicked(self):
+        """Item row clicked."""
+        print 'item clicked in list: {}'.format(self.currentItem().text())
 
-    def keyPressEvent(self, event):
+    def key_press_event(self, event):
+        """Key movement processing.
+        Arrow keys move the selected list item up/down
+        Return key generates a submit situation by making the item as
+        the next available command to processes.
+        """
         row = self.currentRow()
         if event.key() == Qt.Key_Up:
             if row > 0:
@@ -47,25 +103,34 @@ class MDIHistory(QListWidget, CMDWidget):
 
         self.setCurrentRow(row)
 
+    #def focusInEvent(self, event):
+    #    super(MDIHistory, self).focusInEvent(event)
+    #    pass
 
-    def focusInEvent(self, event):
-        super(MDIHistory, self).focusInEvent(event)
-        pass
-
-
-    def setHistory(self, stringList):
-        print('Clear and load history to list')
+    def set_history(self, items_list):
+        """Clear and reset the history in the list.
+        item_list is a list of strings."""
+        print 'Clear and load history to list'
         self.clear()
-        self.addItems(stringList)
+        for item in items_list:
+            row_item = QListWidgetItem()
+            row_item.setText(item)
+            row_item.setData(MDIHistory.MDQQ_ROLE, MDIHistory.MDIQ_DONE)
+            self.addItem(row_item)
 
 
+        #self.addItems(history_list)
 
     def initialize(self):
+        """Load up starting data and set signal connections."""
         history = STATUS.mdi_history.value
-        self.addItems(history)
-        self.clicked.connect(self.rowClicked)
-        STATUS.mdi_history.notify(self.setHistory)
+        self.set_history(history)
+        self.clicked.connect(self.row_clicked)
+        #STATUS.mdi_history.notify(self.set_history)
+        self.mdi_entry_widget = self.parent().findChild(MDIEntry, self.mdi_entryline_name)
+        #print 'find child: {}'.format(self.parent().findChild(MDIEntry, 'mdiEntry'))
 
 
     def terminate(self):
+        """Teardown processing."""
         pass


### PR DESCRIPTION
MDI History/Queue Widget for use in Designer. (v1)
Purpose/Features:
[1] Supports display of the MDI history and selecting items from that history for running.
[2] Supports stacking up MDI commands while an existing MDI is being executed.  MDI command in flight has a "play" triangle icon beside it.  Waiting commands have a "pause" icon beside them.
[3] supports run from selected line/row via Slot
[4] supports clearing queued to run (i.e. "paused") MDI commands via Slot
[5] uses QTimer to create a 1 second heart beat to process commands
[6] supports pause of queue processing via Slot

Key changes made to existing works:
status.py:  commented out code to "remove" entry of duplicate commands.  For queue to work effectively from a usability angle you need to be able to add duplicate commands.

input_widgets/designer_plugins.py: 
added in definition for new widget.

mdientry_widget:
new slot to set the MDI text.

mdihistory_widget:
net new widget