### PR TITLE
Hal group cherrypick

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,7 @@ linuxcnc/configs/**/.*.json
 linuxcnc/configs/**/.*.pickle
 qtpyvcp/.project
 qtpyvcp/.pydevproject
+<<<<<<< HEAD
+=======
+qtpyvcp/.settings/
+>>>>>>> 77cbd02... updated ignore.

--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,5 @@ linuxcnc/configs/**/*.old
 # persistent data files 
 linuxcnc/configs/**/.*.json
 linuxcnc/configs/**/.*.pickle
+qtpyvcp/.project
+qtpyvcp/.pydevproject

--- a/qtpyvcp/widgets/hal_widgets/hal_groupbox.py
+++ b/qtpyvcp/widgets/hal_widgets/hal_groupbox.py
@@ -42,13 +42,13 @@ class HalGroupBox(QGroupBox, HALWidget):
 
         # add group-box.enable HAL pin
         self._enable_pin = comp.addPin(obj_name + ".enable", "bit", "in")
-        self._enable_pin.value = self.isVisible()
-        self._enable_pin.valueChanged.connect(self.setVisible)
+        self._enable_pin.value = self.isEnabled()
+        self._enable_pin.valueChanged.connect(self.setEnabled)
 
         # add group-box.visible HAL pin
         self._visible_pin = comp.addPin(obj_name + ".visible", "bit", "in")
-        self._visible_pin.value = self.isEnabled()
-        self._visible_pin.valueChanged.connect(self.setEnabled)
+        self._visible_pin.value = self.isVisible()
+        self._visible_pin.valueChanged.connect(self.setVisible)
 
         if self.isCheckable():
             # add group-box.check HAL pin

--- a/qtpyvcp/widgets/hal_widgets/hal_groupbox.py
+++ b/qtpyvcp/widgets/hal_widgets/hal_groupbox.py
@@ -16,6 +16,7 @@ class HalGroupBox(QGroupBox, HALWidget):
         HAL Pin Name              Type  Direction
         ========================= ===== =========
         qtpyvcp.group-box.enable   bit   in
+        qtpyvcp.group-box.visible  bit   in
         qtpyvcp.group-box.check    bit   in
         qtpyvcp.group-box.checked  bit   out
         ========================= ===== =========
@@ -25,6 +26,7 @@ class HalGroupBox(QGroupBox, HALWidget):
         super(HalGroupBox, self).__init__(parent)
 
         self._enable_pin = None
+        self._visible_pin = None
         self._check_pin = None
         self._checked_pin = None
 
@@ -40,8 +42,13 @@ class HalGroupBox(QGroupBox, HALWidget):
 
         # add group-box.enable HAL pin
         self._enable_pin = comp.addPin(obj_name + ".enable", "bit", "in")
-        self._enable_pin.value = self.isEnabled()
-        self._enable_pin.valueChanged.connect(self.setEnabled)
+        self._enable_pin.value = self.isVisible()
+        self._enable_pin.valueChanged.connect(self.setVisible)
+
+        # add group-box.visible HAL pin
+        self._visible_pin = comp.addPin(obj_name + ".visible", "bit", "in")
+        self._visible_pin.value = self.isEnabled()
+        self._visible_pin.valueChanged.connect(self.setEnabled)
 
         if self.isCheckable():
             # add group-box.check HAL pin


### PR DESCRIPTION
[1] Updated gitignore for eclipse, pydev  files
[2] Added a "visible" pin to the HAL GroupBox widget.  This allows display/suppression of UI through HAL control.  Example usage in BF20 GUI is hiding the manual Tool Change UI elements until the M6 remapped macro runs and activates the digital hal pains to control the widget.