### PR TITLE
Static status gui interaction

### DIFF
--- a/qtpyvcp/plugins/status.py
+++ b/qtpyvcp/plugins/status.py
@@ -612,6 +612,13 @@ class Status(DataPlugin):
                 return False
         return True
 
+    def forceUpdateStaticChannelMembers(self):
+        """Static items need a force update to operate properly with the
+        gui rules.  This needs to be done with consideration to the
+        data structure so as to not "break" things.
+        """
+        self.old['axes'] = None
+
     def initialise(self):
         """Start the periodic update timer."""
 
@@ -624,6 +631,9 @@ class Status(DataPlugin):
         LOG.debug("Starting periodic updates with %ims cycle time",
                   self._cycle_time)
         self.timer.start(self._cycle_time)
+        
+        self.forceUpdateStaticChannelMembers()
+        
 
     def terminate(self):
         """Save persistent data on terminate."""

--- a/qtpyvcp/plugins/status.py
+++ b/qtpyvcp/plugins/status.py
@@ -631,9 +631,8 @@ class Status(DataPlugin):
         LOG.debug("Starting periodic updates with %ims cycle time",
                   self._cycle_time)
         self.timer.start(self._cycle_time)
-        
+
         self.forceUpdateStaticChannelMembers()
-        
 
     def terminate(self):
         """Save persistent data on terminate."""

--- a/qtpyvcp/plugins/status.py
+++ b/qtpyvcp/plugins/status.py
@@ -617,6 +617,7 @@ class Status(DataPlugin):
         gui rules.  This needs to be done with consideration to the
         data structure so as to not "break" things.
         """
+        # TODO: add to this list as needed. Possible to externalise via yaml?
         self.old['axes'] = None
 
     def initialise(self):


### PR DESCRIPTION
Simple fix to resolve rule triggers on stacked (and possibly other?) widgets not behaving correctly for essentially static data items.  i.e. those coming from the ini/config files.  The behaviour indicated that either the rule was not firing (unlikely) or was firing at a point in time when either the widget was not initialised or was not responding to the index value change.

Added a method to status.py that is called at the very end of the initalize() method to allow us to set to None any channel items that are static and benefit from a forced reload.

This is a work around but one that is contained and can be easily backed out later if root cause is found and solved.