### PR TITLE
Expose override reset pins - cheerypick

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,4 @@ linuxcnc/configs/**/.*.pickle
 qtpyvcp/.settings/
 qtpyvcp/.pydevproject
 qtpyvcp/.project
+qtpyvcp/venv/

--- a/qtpyvcp/__init__.py
+++ b/qtpyvcp/__init__.py
@@ -1,4 +1,4 @@
-#import sys;sys.path.append(r'/root/.p2/pool/plugins/org.python.pydev.core_7.5.0.202001101138/pysrc')
+# LiClipse debug start.  Uncomment the next line to enable debugger connection.
 #import pydevd;pydevd.settrace()
 
 import os

--- a/qtpyvcp/app/application.py
+++ b/qtpyvcp/app/application.py
@@ -239,7 +239,6 @@ class VCPApplication(QApplication):
                 w.initialize()
 
     def initialiseFrameworkExposedHalPins(self):
-        print 'Init framwork exposed HAL pins'
         comp = hal.COMPONENTS['qtpyvcp']
         obj_name = 'feed-override'
         self._feed_override_reset = comp.addPin(obj_name + ".reset", "bit", "in")

--- a/qtpyvcp/app/application.py
+++ b/qtpyvcp/app/application.py
@@ -15,6 +15,9 @@ from qtpy.QtWidgets import QApplication, QStyleFactory
 
 import qtpyvcp
 
+from qtpyvcp import hal
+from qtpyvcp.actions.machine_actions import feed_override, rapid_override
+from qtpyvcp.actions.spindle_actions import override as spindle_override
 from qtpyvcp.utilities.logger import initBaseLogger
 from qtpyvcp.plugins import getPlugin
 from qtpyvcp.widgets.base_widgets.base_widget import VCPPrimitiveWidget
@@ -234,6 +237,20 @@ class VCPApplication(QApplication):
         for w in self.allWidgets():
             if isinstance(w, VCPPrimitiveWidget):
                 w.initialize()
+
+    def initialiseFrameworkExposedHalPins(self):
+        print 'Init framwork exposed HAL pins'
+        comp = hal.COMPONENTS['qtpyvcp']
+        obj_name = 'feed-override'
+        self._feed_override_reset = comp.addPin(obj_name + ".reset", "bit", "in")
+        self._feed_override_reset.valueChanged.connect(feed_override.reset)
+        obj_name = 'rapid-override'
+        self._rapid_override_reset = comp.addPin(obj_name + ".reset", "bit", "in")
+        self._rapid_override_reset.valueChanged.connect(rapid_override.reset)
+        obj_name = 'spindle-override'
+        self._spindle_override_reset = comp.addPin(obj_name + ".reset", "bit", "in")
+        self._spindle_override_reset.valueChanged.connect(spindle_override.reset)
+
 
     def terminateWidgets(self):
         LOG.debug("Terminating widgets")

--- a/qtpyvcp/app/application.py
+++ b/qtpyvcp/app/application.py
@@ -250,7 +250,6 @@ class VCPApplication(QApplication):
         self._spindle_override_reset = comp.addPin(obj_name + ".reset", "bit", "in")
         self._spindle_override_reset.valueChanged.connect(spindle_override.reset)
 
-
     def terminateWidgets(self):
         LOG.debug("Terminating widgets")
         for w in self.allWidgets():

--- a/qtpyvcp/app/launcher.py
+++ b/qtpyvcp/app/launcher.py
@@ -82,6 +82,10 @@ def launch_application(opts, config):
     app.initialiseWidgets()
     log_time('done initializing widgets')
 
+    LOG.debug('Initalizing framework exposed HAL pins')
+    app.initialiseFrameworkExposedHalPins()
+    log_time('done initalizing framework exposed HAL pins')
+
     hal_comp.ready()
 
     # load any post GUI hal file


### PR DESCRIPTION
Housekeeping:
.gitignore:  added exclude for pycharm virtual python environment
qtpyvcp/__init__.py: added comment re LiClipse and simple instruction for enable debug facility.

Purpose of PR: For the most part physical buttons/switches to control aspects of linuxcnc can be done via HAL without the gui.  However the override reset capabilities is more fiddly via HAL than it needs to be.  linuxcnc python interface provides a nice interface to this.  So as a convenience and to provide a clear and simple interface have exposed reset pins at the qtpyvcp level for:
spindle-override
rapid-override
feed-override
