### PR TITLE
Plugin to export specifc HAL pins and associated linuxcnc action.

### DIFF
--- a/qtpyvcp/plugins/exported_hal.py
+++ b/qtpyvcp/plugins/exported_hal.py
@@ -1,0 +1,44 @@
+"""Exported HAL Plugin
+
+This plugin exposes specific machine or program functions via HAL.
+This is a framework level exposure which means a VCP does not
+need to do anything specific other than enable the plugin
+to have a number of standard Linuxcnc functions exposed via the
+linuxcnc python bindings exposed via HAL.
+
+ToDO: look to further yaml configuration options
+"""
+
+from qtpyvcp.utilities.logger import getLogger
+from qtpyvcp.plugins import DataPlugin
+
+from qtpyvcp import hal
+from qtpyvcp.actions.machine_actions import feed_override, rapid_override
+from qtpyvcp.actions.spindle_actions import override as spindle_override
+
+
+LOG = getLogger(__name__)
+
+
+class ExportedHal(DataPlugin):
+    def __init__(self, **kwargs):
+        super(ExportedHal, self).__init__()
+
+    def initialiseFrameworkExposedHalPins(self):
+        comp = hal.COMPONENTS['qtpyvcp']
+        obj_name = 'feed-override'
+        self._feed_override_reset = comp.addPin(obj_name + ".reset", "bit", "in")
+        self._feed_override_reset.valueChanged.connect(feed_override.reset)
+        obj_name = 'rapid-override'
+        self._rapid_override_reset = comp.addPin(obj_name + ".reset", "bit", "in")
+        self._rapid_override_reset.valueChanged.connect(rapid_override.reset)
+        obj_name = 'spindle-override'
+        self._spindle_override_reset = comp.addPin(obj_name + ".reset", "bit", "in")
+        self._spindle_override_reset.valueChanged.connect(spindle_override.reset)
+
+    def initialise(self):
+        LOG.debug('Initalizing framework exposed HAL pins')
+        self.initialiseFrameworkExposedHalPins()
+
+    def terminate(self):
+        pass

--- a/qtpyvcp/yaml_lib/default_config.yml
+++ b/qtpyvcp/yaml_lib/default_config.yml
@@ -63,6 +63,9 @@ data_plugins:
         NC Files: ~/linuxcnc/nc_files
       network_locations:
 
+    exportedhal:
+        provider: qtpyvcp.plugins.exported_hal:ExportedHal
+
 dialogs:
   open_file:
     provider: qtpyvcp.widgets.dialogs.open_file_dialog:OpenFileDialog


### PR DESCRIPTION
This is intended to be a simple and light weight way to expose HAL pins of limited core linuxcnc functions/actions so that VCP developers get some stuff for free.