### PR TITLE
BUG: Do not clear text value when default is used

### DIFF
--- a/qtpyvcp/widgets/input_widgets/setting_slider.py
+++ b/qtpyvcp/widgets/input_widgets/setting_slider.py
@@ -63,11 +63,7 @@ class VCPSettingsLineEdit(QLineEdit, VCPAbstractSettingsWidget):
     def setDisplayValue(self, value):
         self.blockSignals(True)
 
-        if value == self._setting.default_value:
-            self.setText('')
-
-        else:
-            self.setText(self.formatValue(value))
+        self.setText(self.formatValue(value))
 
         self.blockSignals(False)
 

--- a/qtpyvcp/widgets/input_widgets/setting_slider.py
+++ b/qtpyvcp/widgets/input_widgets/setting_slider.py
@@ -62,9 +62,7 @@ class VCPSettingsLineEdit(QLineEdit, VCPAbstractSettingsWidget):
 
     def setDisplayValue(self, value):
         self.blockSignals(True)
-
         self.setText(self.formatValue(value))
-
         self.blockSignals(False)
 
     def initialize(self):
@@ -86,8 +84,6 @@ class VCPSettingsLineEdit(QLineEdit, VCPAbstractSettingsWidget):
                 self._setting.setValue(self._tmp_value)
             else:
                 self.setDisplayValue(self._setting.getValue())
-
-            self.setPlaceholderText(self.formatValue(self._setting.default_value))
 
             self._setting.notify(self.setDisplayValue)
 


### PR DESCRIPTION
Clearing the text value when the desired value equals the default value
causes an issue when using the control as the value for a parameter in
an ngc call since the SubCallButton uses the text value of the control
as the parameter value. In this scenario there is no way to use the
default value as the settings actual value (that I know of) since the control sets the
text to ''.

Thanks for the amazing work on qtpyvcp and probe_basic. It is very much appreciated.