### PR TITLE
ENH: Allow arithmetic expressions in DROLineEdit

### DIFF
--- a/qtpyvcp/widgets/base_widgets/eval_line_edit.py
+++ b/qtpyvcp/widgets/base_widgets/eval_line_edit.py
@@ -39,4 +39,3 @@ class EvalLineEdit(QLineEdit):
             self.setText("{}".format(eval(self.text())))
         except Exception:
             LOG.exception('Error evaluating numeric expression "{}".'.format(self.text()))
-

--- a/qtpyvcp/widgets/base_widgets/eval_line_edit.py
+++ b/qtpyvcp/widgets/base_widgets/eval_line_edit.py
@@ -3,6 +3,8 @@ from __future__ import division
 from qtpy.QtWidgets import QLineEdit
 from qtpyvcp.utilities import logger
 
+from simpleeval import simple_eval
+
 LOG = logger.getLogger(__name__)
 
 
@@ -41,6 +43,6 @@ class EvalLineEdit(QLineEdit):
         elif self.text().startswith(('+', '*', '/', '-=')):
             self.setText(self.orig_value + self.text().replace('=', ''))
         try:
-            self.setText("{}".format(eval(self.text())))
+            self.setText("{}".format(simple_eval(self.text())))
         except Exception:
             LOG.exception('Error evaluating numeric expression "{}".'.format(self.text()))

--- a/qtpyvcp/widgets/base_widgets/eval_line_edit.py
+++ b/qtpyvcp/widgets/base_widgets/eval_line_edit.py
@@ -16,6 +16,8 @@ class EvalLineEdit(QLineEdit):
     Any expression that begins with an operator (except -, see below), will be applied to the current value
     (ex. if current position is 20 and the user enters /2, then the resulting value will be 10).
 
+    Any entry that consists of a single - will invert the sign of the current value.
+
     NB: If the expression starts with '-' it will be interpreted as negating the value following it.
         This means that you cannot enter -10 and have that value subtract from the current value
         because there is no way to determine if the you wanted to subtract 10, or set the current
@@ -33,7 +35,10 @@ class EvalLineEdit(QLineEdit):
         self.orig_value = self.text()
 
     def evaluate_(self):
-        if self.text().startswith(('+', '*', '/', '-=')):
+        if self.text().strip() == '-':
+            # change sign if entry is just a '-'
+            self.setText('-' + self.orig_value)
+        elif self.text().startswith(('+', '*', '/', '-=')):
             self.setText(self.orig_value + self.text().replace('=', ''))
         try:
             self.setText("{}".format(eval(self.text())))

--- a/qtpyvcp/widgets/input_widgets/dro_line_edit.py
+++ b/qtpyvcp/widgets/input_widgets/dro_line_edit.py
@@ -5,7 +5,7 @@ DROLineEdit
 """
 
 from qtpy.QtCore import Property
-from eval_line_edit import EvalLineEdit
+from qtpyvcp.widgets.base_widgets.eval_line_edit import EvalLineEdit
 
 from qtpyvcp.widgets.base_widgets.dro_base_widget import DROBaseWidget, Axis, LatheMode
 from qtpyvcp.actions.machine_actions import issue_mdi

--- a/qtpyvcp/widgets/input_widgets/dro_line_edit.py
+++ b/qtpyvcp/widgets/input_widgets/dro_line_edit.py
@@ -5,7 +5,7 @@ DROLineEdit
 """
 
 from qtpy.QtCore import Property
-from qtpy.QtWidgets import QLineEdit
+from eval_line_edit import EvalLineEdit
 
 from qtpyvcp.widgets.base_widgets.dro_base_widget import DROBaseWidget, Axis, LatheMode
 from qtpyvcp.actions.machine_actions import issue_mdi
@@ -14,7 +14,7 @@ from qtpyvcp.utilities import logger
 LOG = logger.getLogger(__name__)
 
 
-class DROLineEdit(QLineEdit, DROBaseWidget):
+class DROLineEdit(EvalLineEdit, DROBaseWidget):
     """DROLineEdit
 
     DRO that supports typing in desired position to set work coordinate offset.

--- a/qtpyvcp/widgets/input_widgets/eval_line_edit.py
+++ b/qtpyvcp/widgets/input_widgets/eval_line_edit.py
@@ -1,0 +1,42 @@
+# import to get true floating point division even if the arguments are ints (ex. 1/2 => 0.5, not 0)
+from __future__ import division
+from qtpy.QtWidgets import QLineEdit
+from qtpyvcp.utilities import logger
+
+LOG = logger.getLogger(__name__)
+
+
+class EvalLineEdit(QLineEdit):
+    """EvalLineEdit
+
+    This control adds support for evaluating mathematical expressions.
+
+    Any valid expression will be evaluated (ex. -(10+5)*(1.0/2.0) will be evaluated to -2.5).
+
+    Any expression that begins with an operator (except -, see below), will be applied to the current value
+    (ex. if current position is 20 and the user enters /2, then the resulting value will be 10).
+
+    NB: If the expression starts with '-' it will be interpreted as negating the value following it.
+        This means that you cannot enter -10 and have that value subtract from the current value
+        because there is no way to determine if the you wanted to subtract 10, or set the current
+        value to -10. In order to subtract from the current value you must use '-=' instead of
+        just '-'. This syntax may be used with all operators (ex. +=, /=, *=), but it is only
+        required for subtraction.
+    """
+
+    def __init__(self, parent=None):
+        super(EvalLineEdit, self).__init__(parent)
+        self.orig_value = ''
+        self.returnPressed.connect(self.evaluate_)
+
+    def focusInEvent(self, event):
+        self.orig_value = self.text()
+
+    def evaluate_(self):
+        if self.text().startswith(('+', '*', '/', '-=')):
+            self.setText(self.orig_value + self.text().replace('=', ''))
+        try:
+            self.setText("{}".format(eval(self.text())))
+        except Exception:
+            LOG.exception('Error evaluating numeric expression "{}".'.format(self.text()))
+

--- a/setup.py
+++ b/setup.py
@@ -92,6 +92,7 @@ setup(
         'vtk',
         'pyqtgraph',
         'more-itertools',
+        'simpleeval',
     ],
     entry_points={
         'console_scripts': [


### PR DESCRIPTION
ENH: Allow arithmetic expressions in DROLineEdit

Problem:
- It is often useful to be able to set the current work offset for
  an axis using an expression (ex. 120/25.4, or just /2 to divide
  the current offset by 2).

Solution:
- Create a new EvalLineEdit class that will invoke the eval operator
  on the current text and have DROLineEdit inherit from it.

- If the expression starts with an operator it is applied to
  the current value for this DRO. For example, entering '/2' into
  the DROLineEdit will divide the current value by 2.

- If the expression is valid, the text will be set to the result.
  Otherwise, the expression is left as is.

NB: Any control that wants to evaluate arithmetic expressions can
    inherit from EvalLineEdit, and gain that functionality. No other
    changes are required for the control.
