### PR TITLE
vtk_backplot: enable anti-aliasing

### DIFF
--- a/qtpyvcp/widgets/display_widgets/vtk_backplot/vtk_backplot.py
+++ b/qtpyvcp/widgets/display_widgets/vtk_backplot/vtk_backplot.py
@@ -285,6 +285,11 @@ class VTKCanon(StatCanon):
     def get_path_actors(self):
         return self.path_actors
 
+# turn on antialiasing
+from PyQt5.QtOpenGL import QGLFormat
+f = QGLFormat()
+f.setSampleBuffers(True)
+QGLFormat.setDefaultFormat(f)
 
 class VTKBackPlot(QVTKRenderWindowInteractor, VCPWidget, BaseBackPlot):
     def __init__(self, parent=None):


### PR DESCRIPTION
<img width="273" alt="Bildschirmfoto 2020-11-21 um 19 11 18" src="https://user-images.githubusercontent.com/730123/99884440-92ec2780-2c2e-11eb-89a6-bb149f441ec9.png">

versus

<img width="225" alt="Bildschirmfoto 2020-11-21 um 19 19 52" src="https://user-images.githubusercontent.com/730123/99884438-92539100-2c2e-11eb-8052-70a9f11c304a.png">
