### PR TITLE
vtk_backplot: fix wrongly visible backfaces on Linux with Intel video card

### DIFF
--- a/qtpyvcp/widgets/display_widgets/vtk_backplot/vtk_backplot.py
+++ b/qtpyvcp/widgets/display_widgets/vtk_backplot/vtk_backplot.py
@@ -1955,6 +1955,10 @@ class Tool:
         self.actor = vtk.vtkActor()
         self.actor.SetMapper(mapper)
 
+        # Avoid visible backfaces on Linux with some video cards like intel
+        # From: https://stackoverflow.com/questions/51357630/vtk-rendering-not-working-as-expected-inside-pyqt?rq=1#comment89720589_51360335
+        self.actor.GetProperty().SetBackfaceCulling(1)
+
     def get_actor(self):
         return self.actor
 


### PR DESCRIPTION
From https://stackoverflow.com/questions/51357630/vtk-rendering-not-working-as-expected-inside-pyqt?rq=1#comment89720589_51360335.

![Screenshot_at_2020-11-21_20-10-16](https://user-images.githubusercontent.com/730123/99901171-df7a4600-2cb4-11eb-8cfc-e4cca8db715f.png)
