### PR TITLE
DROLineEdit stops updating when being edited.

### DIFF
--- a/qtpyvcp/widgets/input_widgets/dro_line_edit.py
+++ b/qtpyvcp/widgets/input_widgets/dro_line_edit.py
@@ -58,10 +58,10 @@ class DROLineEdit(EvalLineEdit, DROBaseWidget):
     def updateValue(self, pos=None):
         if self.pos.report_actual_pos and self.isModified():
             # Only update if commanded position changes when user is editing.
-            if self.last_commanded_pos != self.status.stat.position[self._anum]:
-                super(DROLineEdit, self).updateValue(pos)
-        else:
-            super(DROLineEdit, self).updateValue(pos)
+            if self.last_commanded_pos == self.status.stat.position[self._anum]:
+                return None
+
+        super(DROLineEdit, self).updateValue(pos)
 
     def setCurrentPos(self):
         # Run once user starts editing field.

--- a/qtpyvcp/widgets/input_widgets/dro_line_edit.py
+++ b/qtpyvcp/widgets/input_widgets/dro_line_edit.py
@@ -25,8 +25,11 @@ class DROLineEdit(EvalLineEdit, DROBaseWidget):
 
         self.returnPressed.connect(self.onReturnPressed)
         self.editingFinished.connect(self.onEditingFinished)
+        self.textEdited.connect(self.setCurrentPos)
 
         issue_mdi.bindOk(widget=self)
+        
+        self.last_commanded_pos = self.status.stat.position[self._anum]
 
     def onReturnPressed(self):
         try:
@@ -51,3 +54,15 @@ class DROLineEdit(EvalLineEdit, DROBaseWidget):
 
     def onEditingFinished(self):
         self.updateValue()
+
+    def updateValue(self, pos=None):
+        if self.pos.report_actual_pos and self.isModified():
+            # Only update if commanded position changes when user is editing.
+            if self.last_commanded_pos != self.status.stat.position[self._anum]:
+                super(DROLineEdit, self).updateValue(pos)
+        else:
+            super(DROLineEdit, self).updateValue(pos)
+
+    def setCurrentPos(self):
+        # Run once user starts editing field.
+        self.last_commanded_pos = self.status.stat.position[self._anum]

--- a/qtpyvcp/widgets/input_widgets/dro_line_edit.py
+++ b/qtpyvcp/widgets/input_widgets/dro_line_edit.py
@@ -4,7 +4,7 @@ DROLineEdit
 
 """
 
-from qtpy.QtCore import Property
+from qtpy.QtCore import Qt, Property
 from qtpyvcp.widgets.base_widgets.eval_line_edit import EvalLineEdit
 
 from qtpyvcp.widgets.base_widgets.dro_base_widget import DROBaseWidget, Axis, LatheMode
@@ -65,4 +65,11 @@ class DROLineEdit(EvalLineEdit, DROBaseWidget):
 
     def setCurrentPos(self):
         # Run once user starts editing field.
+        self.isEdited = True
         self.last_commanded_pos = self.status.stat.position[self._anum]
+    
+    def keyPressEvent(self, e):
+        if e.key() == Qt.Key_Escape:
+            super(DROLineEdit, self).updateValue()
+        else:
+            super(DROLineEdit, self).keyPressEvent(e)


### PR DESCRIPTION
Resolves issue #72.

DROLineEdit will stop updating when user starts editing, until either the commanded position changes or the user presses the escape key with the lineEdit in focus.