### PR TITLE
Flute count datachannel

### DIFF
--- a/qtpyvcp/plugins/tool_table.py
+++ b/qtpyvcp/plugins/tool_table.py
@@ -195,6 +195,30 @@ class ToolTable(DataPlugin):
         if item is None:
             return self.TOOL_TABLE[STAT.tool_in_spindle]
         return self.TOOL_TABLE[STAT.tool_in_spindle].get(item[0].upper())
+    
+    @DataChannel
+    def get_flutecount(self, chan):
+        """Retrieves number of flutes of the current tool based on remark.
+
+        A number preceding "fl" in the remark of the tool is used (not case-sensitive)
+        Single space between number is allowed.
+        Examples:
+        "3fl"
+        "6 flute"
+
+        Rules channel syntax::
+
+            tooltable:get_flutecount
+
+        :return: int
+        """
+        remark = self.TOOL_TABLE[STAT.tool_in_spindle].get("R").lower()
+        #remark = "1/8\" 3 Flute 45 deg Helix 0.375 loc 1.500 oal".lower()
+        fluteCountList = (re.findall(r"(\d+)fl", remark) + re.findall(r"(\d+) fl", remark))
+        if len(fluteCountList) == 0:
+            return 1
+        else:
+            return int(fluteCountList[0])
 
     def initialise(self):
         self.fs_watcher = QFileSystemWatcher()

--- a/qtpyvcp/plugins/tool_table.py
+++ b/qtpyvcp/plugins/tool_table.py
@@ -213,8 +213,7 @@ class ToolTable(DataPlugin):
         :return: int
         """
         remark = self.TOOL_TABLE[STAT.tool_in_spindle].get("R").lower()
-        #remark = "1/8\" 3 Flute 45 deg Helix 0.375 loc 1.500 oal".lower()
-        fluteCountList = (re.findall(r"(\d+)fl", remark) + re.findall(r"(\d+) fl", remark))
+        fluteCountList = re.findall(r"(\d+)\s*fl", remark)
         if len(fluteCountList) == 0:
             return 1
         else:

--- a/qtpyvcp/widgets/qtdesigner/rules_editor.py
+++ b/qtpyvcp/widgets/qtdesigner/rules_editor.py
@@ -641,9 +641,9 @@ class RulesEditor(QtWidgets.QDialog):
                     errors.append("Rule #{} expression returned '{}', but expected '{}'."
                                   .format(idx + 1, act_typ.__name__, exp_typ.__name__))
 
-            except:
-                LOG.exception("Error evaluating Rule #{} expression.".format(idx))
-                errors.append("Rule #{} expression is not valid.".format(idx))
+            except Exception as e:
+                LOG.exception("Error evaluating Rule #{} expression. Exception was: {}".format(idx, e))
+                errors.append("Rule #{} expression is not valid.\n{}".format(idx, e))
 
         if len(errors) > 0:
             error_msg = os.linesep.join(errors)
@@ -666,7 +666,7 @@ class RulesEditor(QtWidgets.QDialog):
         is_valid, message = self.is_data_valid()
         if is_valid:
             data = json.dumps(self.rules)
-            print json.dumps(self.rules, sort_keys=True, indent=4)
+            #print json.dumps(self.rules, sort_keys=True, indent=4)
             formWindow = QtDesigner.QDesignerFormWindowInterface.findFormWindow(self.widget)
             if formWindow:
                 formWindow.cursor().setProperty("rules", data)


### PR DESCRIPTION
Adds a flute count datachannel.

Flute count is obtained from the remark in the tooltable. Any number preceding the letters "fl" (not case sensitive) will be taken as flute count, so "3fl" "3 fl" or "3 flute" all work.

With this datachannel it becomes possible to implement chipload displays in a VCP using the rules editor.