### PR TITLE
Mdi history and mdi line rtn key behaviour

### DIFF
--- a/qtpyvcp/widgets/input_widgets/mdientry_widget.py
+++ b/qtpyvcp/widgets/input_widgets/mdientry_widget.py
@@ -7,6 +7,7 @@ from qtpyvcp.plugins import getPlugin
 from qtpyvcp.utilities.info import Info
 from qtpyvcp.actions.machine_actions import issue_mdi
 from qtpyvcp.widgets.base_widgets.base_widget import CMDWidget
+from gtk import TRUE
 
 STATUS = getPlugin('status')
 INFO = Info()
@@ -29,6 +30,7 @@ class MDIEntry(QLineEdit, CMDWidget):
     def __init__(self, parent=None):
         super(MDIEntry, self).__init__(parent)
 
+        self.mdi_rtnkey_behaviour_supressed = False
         self.mdi_history_size = 100
         completer = QCompleter()
         completer.setCaseSensitivity(Qt.CaseInsensitive)
@@ -51,10 +53,16 @@ class MDIEntry(QLineEdit, CMDWidget):
 
     @Slot()
     def submit(self):
-        cmd = str(self.text()).strip()
-        issue_mdi(cmd)
-        self.setText('')
-        STATUS.mdi_history.setValue(cmd)
+        # Only support submit from Return Key if not suppressed
+        # This is used to stop standalone behaviour by the MDIHistory widget.
+        # MDIHisttory uses its handle to this widget to set
+        # mdi_rtnkey_behaviour_supressed = True.
+        # MDIHistory will now manage the MDILine submission process
+        if not self.mdi_rtnkey_behaviour_supressed:
+            cmd = str(self.text()).strip()
+            issue_mdi(cmd)
+            self.setText('')
+            STATUS.mdi_history.setValue(cmd)
 
     @Slot(QListWidgetItem)
     def setMDIText(self, listItem):
@@ -70,6 +78,12 @@ class MDIEntry(QLineEdit, CMDWidget):
     def focusInEvent(self, event):
         super(MDIEntry, self).focusInEvent(event)
         self.completer().complete()
+
+    def supress_rtn_key_behaviour(self):
+        self.mdi_rtnkey_behaviour_supressed = True
+
+    def enable_rtn_key_behaviour(self):
+        self.mdi_rtnkey_behaviour_supressed = False
 
     def initialize(self):
         history = STATUS.mdi_history.value

--- a/qtpyvcp/widgets/input_widgets/mdientry_widget.py
+++ b/qtpyvcp/widgets/input_widgets/mdientry_widget.py
@@ -7,7 +7,6 @@ from qtpyvcp.plugins import getPlugin
 from qtpyvcp.utilities.info import Info
 from qtpyvcp.actions.machine_actions import issue_mdi
 from qtpyvcp.widgets.base_widgets.base_widget import CMDWidget
-from gtk import TRUE
 
 STATUS = getPlugin('status')
 INFO = Info()

--- a/qtpyvcp/widgets/input_widgets/mdihistory_widget.py
+++ b/qtpyvcp/widgets/input_widgets/mdihistory_widget.py
@@ -296,6 +296,8 @@ class MDIHistory(QListWidget, CMDWidget):
         for win_name, obj in qtpyvcp.WINDOWS.items():
             if hasattr(obj, str(self.mdi_entryline_name)):
                 self.mdi_entry_widget = getattr(obj, self.mdi_entryline_name)
+                # Use the handle to supress the widgets Rtn key behaviour
+                self.mdi_entry_widget.supress_rtn_key_behaviour()
                 break
         # Setup the basic timer system as a heart beat on the queue
         self.heart_beat_timer = QTimer(self)

--- a/qtpyvcp/widgets/input_widgets/mdihistory_widget.py
+++ b/qtpyvcp/widgets/input_widgets/mdihistory_widget.py
@@ -166,6 +166,12 @@ class MDIHistory(QListWidget, CMDWidget):
             self.addItem(row_item)
         else:
             self.insertItem(0, row_item)
+        
+        # Set the recently added item as the "current" item
+        # if the queue is not paused this will quickly get overridden
+        # to the executing item highlight mode
+        self.clearSelection()
+        self.setCurrentItem(row_item)
 
         # put the command onto the status channel mdi history
         STATUS.mdi_history.setValue(cmd)
@@ -279,6 +285,8 @@ class MDIHistory(QListWidget, CMDWidget):
                 row_item.setIcon(QIcon())
 
             elif row_item_data == MDIHistory.MDIQ_TODO:
+                self.clearSelection()
+                self.setCurrentItem(row_item)
                 cmd = str(row_item.text()).strip()
                 row_item.setData(MDIHistory.MDQQ_ROLE, MDIHistory.MDIQ_RUNNING)
                 row_item.setIcon(self.icon_run)
@@ -301,7 +309,7 @@ class MDIHistory(QListWidget, CMDWidget):
                 break
         # Setup the basic timer system as a heart beat on the queue
         self.heart_beat_timer = QTimer(self)
-        # use a 1 second timer
+        # use a sub-second second timer
         self.heart_beat_timer.start(250)
         self.heart_beat_timer.timeout.connect(self.heartBeat)
 


### PR DESCRIPTION
FEATURE: MDIHistory and MDILineEntry did not play nicely together.
When pushing the return key after keyboard entry of gcode while the item would execute it would appear as a blank line in the MDIHistory widget. This was caused by the keypress support in MDILine executing the command itself and not passing it to MDIHistory to manage.  This pull request fixes that by having MDIHistory set a flag on the MDILine. This flag is tested to determine how MDILine should react to return-key presses.

FEATURE: The highlighting of newly entered items into MDIHistory and executing items was not necessarily obvious or consistent. So now the last entered item is highlighted via the selected highlight colour on the ListWidget. The currently executing line is also highlighted in the same manner along with the existing icon method.