### PR TITLE
Enhance bar indicator for 100%  value separate from max

### DIFF
--- a/qtpyvcp/widgets/base_widgets/bar_indicator.py
+++ b/qtpyvcp/widgets/base_widgets/bar_indicator.py
@@ -14,6 +14,7 @@ class BarIndicatorBase(QWidget):
         self._value = 100
         self._minimum = 0.0
         self._maximum = 100.0
+        self._value_at_100_percent = 100.0
         self._format = '{p}%'
 
         self._text_color = QColor(0, 0, 0)
@@ -226,9 +227,18 @@ class BarIndicatorBase(QWidget):
         self.adjustTransformation()
         self.update()
 
+    @Property(float)
+    def valueAt100Percent(self):
+        return self._value_at_100_percent
+    
+    @valueAt100Percent.setter
+    def valueAt100Percent(self, value_at):
+        self._value_at_100_percent = value_at
+        self.update()
+
     def text(self):
         values = {'v': self._value,
-                  'p': int((self._value * 100 / self._maximum) + .5)}
+                  'p': int((self._value * 100 / self._value_at_100_percent) + .5)}
         try:
             return self.format.encode("utf-8").format(**values)
         except:


### PR DESCRIPTION
This allows a separate value to be used to drive when the bar text % label is at 100% compared to max value.  For example where a motor can drive to 300% normal torque you would want it to show 300% in the label when the bar is fully coloured.  Making this new target value the same as max maintains existing behaviour.  It is easy to see what is happening by trying different values in QTDesigner.