### PR TITLE
MDI History Improvements to delete functionality

### DIFF
--- a/qtpyvcp/plugins/status.py
+++ b/qtpyvcp/plugins/status.py
@@ -198,10 +198,17 @@ class Status(DataPlugin):
             LOG.debug("---------mdi history delete attempt index out of range")
 
     def mdi_swap_entries(self, index1, index2):
-        """Swicth two entries about."""
+        """Switch two entries about."""
         chan = self.mdi_history
         cmds = chan.value
         cmds[index2], cmds[index1] = cmds[index1], cmds[index2]
+        chan.signal.emit(cmds)
+    
+    def mdi_remove_all(self):
+        """Remove all entries in mdi history"""
+        chan = self.mdi_history
+        cmds = chan.value
+        cmds.clear()
         chan.signal.emit(cmds)
 
     @DataChannel

--- a/qtpyvcp/widgets/input_widgets/mdihistory_widget.py
+++ b/qtpyvcp/widgets/input_widgets/mdihistory_widget.py
@@ -13,8 +13,6 @@ running commands to complete.
 
 ToDo:
     * add/test for styling based on the class queue codes
-    * be able to select and remove unwanted commands from the history
-    * be able to select a row and run commands from that point upwards
 
 """
 import os
@@ -107,7 +105,7 @@ class MDIHistory(QListWidget, CMDWidget):
 
     @Slot()
     def clearQueue(self):
-        """Clear queue items yet to be run."""
+        """Clear queue items pending run state for items yet to be run."""
         if self.mdi_listorder_natural:
             list_length = list(range(self.count()))
         else:
@@ -123,25 +121,37 @@ class MDIHistory(QListWidget, CMDWidget):
 
     @Slot()
     def removeSelectedItem(self):
-        """Remove the selected line"""
-        row = self.currentRow()
-        if row != -1:
-            self.takeItem(row)
-            if not self.mdi_listorder_natural:
-                STATUS.mdi_remove_entry(row)
-                if row >= self.count():
-                    row = self.count()-1
-                self.setCurrentRow(row)
+        """Remove the selected lines"""
+        selItems = self.selectedItems()
+        if len(selItems) > 0:
+            if self.mdi_listorder_natural:
+                firstItemRow = self.row(selItems[0]) - 1
             else:
-                # The order of MDI is latest LAST in the list.
-                # framework mdi history is latest FIRST in the list.
-                history_length = len(STATUS.mdi_history.value)
-                history_target_row = history_length-1-row 
-                STATUS.mdi_remove_entry(history_target_row)
-                row = row - 1
-                if row < 0 and self.count() > 0:
-                    row = 0
-                self.setCurrentRow(row)
+                firstItemRow = self.row(selItems[len(selItems)-1])
+            for item in selItems:
+                row = self.row(item)
+                self.takeItem(row)
+                if not self.mdi_listorder_natural:
+                    STATUS.mdi_remove_entry(row)
+                else:
+                    # The order of MDI is latest LAST in the list.
+                    # framework mdi history is latest FIRST in the list.
+                    history_length = len(STATUS.mdi_history.value)
+                    history_target_row = history_length-1-row 
+                    STATUS.mdi_remove_entry(history_target_row)
+            # select an item that makes sense for the case of a single
+            # item having been selected and deleted.
+            if firstItemRow < 0 and self.count() > 0:
+                row = 0
+            else:
+                row = firstItemRow
+            self.setCurrentRow(row)
+            
+    @Slot()
+    def removeAll(self):
+        """Remove all items from list and from history"""
+        self.clear()
+        STATUS.mdi_remove_all()
 
     @Slot()
     def runFromSelection(self):


### PR DESCRIPTION
Changes:
- Changed delete row to delete selection.  It will delete all selected items.
- Added method to delete all entries in history
- Added remove all to Status plugin to back up adjustments to mdi history
- Fixed the todo list and a spelling mistake
- Changed comment string in clearQueue to be more explicit as to what is happening

Tested on my UI and behaviour seems solid.

Code should also be able to be merged into the python2_maintenance line.  But a peer review to ensure no py2 v's py3 issues exist would be appropriate.