### PR TITLE
BUG #94 - Fix for subcall ngc file improper existence check

### DIFF
--- a/qtpyvcp/widgets/button_widgets/subcall_button.py
+++ b/qtpyvcp/widgets/button_widgets/subcall_button.py
@@ -56,8 +56,9 @@ class SubCallButton(VCPButton):
 
         subfile = None
         for dir in SUBROUTINE_SEARCH_DIRS:
-            subfile = os.path.join(dir, self._filename)
-            if os.path.isfile(subfile):
+            tempfile = os.path.join(dir, self._filename)
+            if os.path.isfile(tempfile):
+                subfile = tempfile
                 break
 
         if subfile is None:


### PR DESCRIPTION
The code for checking for the existence of an ngc subcall file would not exit where it should on fail due to missing intermediate var.