### PR TITLE
BUG: Unhome axis did not account for gantry 2 jnts to an axis

### DIFF
--- a/qtpyvcp/actions/machine_actions.py
+++ b/qtpyvcp/actions/machine_actions.py
@@ -749,9 +749,12 @@ class unhome:
         if axis.lower() == 'all': # not sure what this is copied from home
             unhome.all()
             return
-        jnum = INFO.COORDINATES.index(axis)
-        LOG.info('Unhoming Axis: {}'.format(axis.upper()))
-        _unhome_joint(jnum)
+        #jnum = INFO.COORDINATES.index(axis)
+        for ax in INFO.ALETTER_JNUM_DICT:
+            #LOG.info('Unhoming Axis: {}'.format(axis.upper()))
+            if axis == ax[0]:
+                LOG.info('Unhoming Axis: {}'.format(ax.upper()))
+                _unhome_joint(INFO.ALETTER_JNUM_DICT[ax])
 
     @staticmethod
     def joint(jnum):


### PR DESCRIPTION
Changed the Axis unhome to now scan and unhome each joint that is linked to the selected axis.

This ensures gantry machines that have a single axis associated with 2 joints are correctly dealt with.  This code should also cope with the situation where an axis with >1 joints associated with it will be correctly unhomed.