### PR TITLE
DOC: fix github link to linuxcnc project

### DIFF
--- a/docs/source/install/bullseye.rst
+++ b/docs/source/install/bullseye.rst
@@ -94,7 +94,7 @@ Create the working directories to hold linuxcnc source and qtpyvcp source::
     cd dev
     mkdir linuxcnc
     cd linuxcnc
-    git clone git://github.com/linuxcnc/linuxcnc.git rip
+    git clone https://github.com/LinuxCNC/linuxcnc.git rip
     cd rip/src
     ./autogen.sh
     ./configure --with-realtime=uspace


### PR DESCRIPTION
Updated link to prevent this error using the previous unauthenticated 
git protocol:

fatal: remote error: 
  The unauthenticated git protocol on port 9418 is no longer supported.
Please see 
https://github.blog/2021-09-01-improving-git-protocol-security-github/ 
for more information.