### PR TITLE
Add basic dialog for manual tool changing

### DIFF
--- a/src/qtpyvcp/widgets/dialogs/toolchange_dialog.py
+++ b/src/qtpyvcp/widgets/dialogs/toolchange_dialog.py
@@ -1,0 +1,83 @@
+#   Copyright (c) 2023 Jose I. Romero
+#      <jir@electrumee.com>
+#
+#   This file is part of QtPyVCP.
+#
+#   QtPyVCP is free software: you can redistribute it and/or modify
+#   it under the terms of the GNU General Public License as published by
+#   the Free Software Foundation, either version 2 of the License, or
+#   (at your option) any later version.
+#
+#   QtPyVCP is distributed in the hope that it will be useful,
+#   but WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#   GNU General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License
+#   along with QtPyVCP.  If not, see <http://www.gnu.org/licenses/>.
+
+import os
+from qtpy import uic
+from qtpy.QtWidgets import QVBoxLayout, QDialog, QDialogButtonBox, QLabel
+
+from qtpyvcp.widgets.dialogs.base_dialog import BaseDialog
+from qtpyvcp.plugins import getPlugin
+
+from qtpyvcp import hal
+
+class ToolChangeDialog(BaseDialog):
+    """Tool Change Dialog
+
+    Manual tool changing dialog component
+
+    This is a qtpyvcp replacement of axis' `hal_manualtoolchange`. It
+    uses the same pin names in the same way, but the HAL component they
+    are under is called `qtpyvcp_manualtoolchange` instead.
+    """
+    def __init__(self, *args, **kwargs):
+        super(ToolChangeDialog, self).__init__(stay_on_top=True)
+
+        self.tt = getPlugin('tooltable')
+        self.tool_number = 0
+
+        default_ui = os.path.join(os.path.dirname(__file__), 'toolchange_dialog.ui')
+
+        self.ui_file = kwargs.get('ui_file', default_ui)
+
+        self.ui = uic.loadUi(self.ui_file, self)
+
+        comp = hal.getComponent("qtpyvcp_manualtoolchange")
+        comp.addPin('number', 's32', 'in')
+        comp.addPin('change', 'bit', 'in')
+        self.changed_pin = self.halcomp.addPin('changed', 'bit', 'out')
+        self.halcomp.addPin('change_button', 'bit', 'in')
+
+        comp.addListener('number', self.prepare_tool)
+        comp.addListener('change', self.on_change)
+        comp.addListener('change_button', self.on_change_button)
+        self.hide()
+
+    def prepare_tool(self, tool_no):
+        if self.tool_number == tool_no: return  # Already prepared this tool
+        tool_data = self.tt.getToolTable().get(tool_no, {})
+        tool_r = tool_data.get('R', 'UNKNOWN')
+        self.ui.lblToolNumber.setText(str(tool_no))
+        self.ui.lblToolRemark.setText(tool_r)
+        self.tool_number = tool_no
+
+    def on_change(self, value=True):
+        if value:
+            self.show()
+        else:
+            self.changed_pin.value = False
+
+    def on_change_button(self, value=True):
+        if value:
+            self.accept()
+
+    def reject(self):
+        pass
+
+    def accept(self):
+        self.changed_pin.value = True
+        self.hide()

--- a/src/qtpyvcp/widgets/dialogs/toolchange_dialog.py
+++ b/src/qtpyvcp/widgets/dialogs/toolchange_dialog.py
@@ -49,8 +49,8 @@ class ToolChangeDialog(BaseDialog):
         comp = hal.getComponent("qtpyvcp_manualtoolchange")
         comp.addPin('number', 's32', 'in')
         comp.addPin('change', 'bit', 'in')
-        self.changed_pin = self.halcomp.addPin('changed', 'bit', 'out')
-        self.halcomp.addPin('change_button', 'bit', 'in')
+        self.changed_pin = comp.addPin('changed', 'bit', 'out')
+        comp.addPin('change_button', 'bit', 'in')
 
         comp.addListener('number', self.prepare_tool)
         comp.addListener('change', self.on_change)

--- a/src/qtpyvcp/widgets/dialogs/toolchange_dialog.ui
+++ b/src/qtpyvcp/widgets/dialogs/toolchange_dialog.ui
@@ -1,0 +1,142 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>Dialog</class>
+ <widget class="QDialog" name="Dialog">
+  <property name="windowModality">
+   <enum>Qt::ApplicationModal</enum>
+  </property>
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>501</width>
+    <height>267</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Manual Tool Change</string>
+  </property>
+  <property name="modal">
+   <bool>true</bool>
+  </property>
+  <layout class="QFormLayout" name="formLayout">
+   <item row="1" column="0">
+    <widget class="QLabel" name="label">
+     <property name="font">
+      <font>
+       <pointsize>16</pointsize>
+      </font>
+     </property>
+     <property name="text">
+      <string>Tool Number:</string>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="0" colspan="2">
+    <widget class="QLabel" name="label_1">
+     <property name="font">
+      <font>
+       <pointsize>16</pointsize>
+      </font>
+     </property>
+     <property name="text">
+      <string>Manual Tool Change Requested&lt;br&gt;Insert the following tool and hit &quot;Done&quot; to continue.</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignCenter</set>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="1">
+    <widget class="QLabel" name="lblToolNumber">
+     <property name="font">
+      <font>
+       <pointsize>24</pointsize>
+      </font>
+     </property>
+     <property name="frameShape">
+      <enum>QFrame::Box</enum>
+     </property>
+     <property name="text">
+      <string>0</string>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="0" colspan="2">
+    <widget class="QPushButton" name="btnDone">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="MinimumExpanding" vsizetype="MinimumExpanding">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="text">
+      <string>Done</string>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="0">
+    <widget class="QLabel" name="label_3">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="Expanding">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="font">
+      <font>
+       <pointsize>16</pointsize>
+      </font>
+     </property>
+     <property name="text">
+      <string>Remark:</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="1">
+    <widget class="QLabel" name="lblToolRemark">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="Expanding">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="frameShape">
+      <enum>QFrame::Box</enum>
+     </property>
+     <property name="frameShadow">
+      <enum>QFrame::Plain</enum>
+     </property>
+     <property name="text">
+      <string>Remarks</string>
+     </property>
+     <property name="alignment">
+      <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections>
+  <connection>
+   <sender>btnDone</sender>
+   <signal>clicked()</signal>
+   <receiver>Dialog</receiver>
+   <slot>accept()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>64</x>
+     <y>220</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>31</x>
+     <y>332</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
+</ui>


### PR DESCRIPTION
Add basic functionality for manual tool changing via dialog, similar to the one built into qtvcp. It displays the tool number and tool remark from the tool table to aid the operator in finding the tool. It implements the same interface as the `hal_manualtoolchange` component, but in a different namespace.