### PR TITLE
program_actions@load: allow bypassing setTaskMode(linuxcnc.MODE_AUTO)

### DIFF
--- a/src/qtpyvcp/actions/program_actions.py
+++ b/src/qtpyvcp/actions/program_actions.py
@@ -21,12 +21,13 @@ from qtpyvcp.actions.base_actions import setTaskMode
 # Program actions
 #==============================================================================
 
-def load(fname, add_to_recents=True):
+def load(fname, add_to_recents=True, switch_to_mode_auto=True):
     if not fname:
         # load a blank file. Maybe should load [DISPLAY] OPEN_FILE
         clear()
 
-    setTaskMode(linuxcnc.MODE_AUTO)
+    if (switch_to_mode_auto):
+        setTaskMode(linuxcnc.MODE_AUTO)
     filter_prog = INFO.getFilterProgram(fname)
     if not filter_prog:
         LOG.debug('Loading NC program: %s', fname)

--- a/src/qtpyvcp/widgets/form_widgets/main_window.py
+++ b/src/qtpyvcp/widgets/form_widgets/main_window.py
@@ -351,7 +351,7 @@ class VCPMainWindow(QMainWindow):
         #print(splash_code)
         if splash_code is not None and os.path.isfile(splash_code):
             # Load after startup to not cause hang and 'Can't set mode while machine is running' error
-            QTimer.singleShot(200, lambda: actions.program.load(splash_code, add_to_recents=False))
+            QTimer.singleShot(200, lambda: actions.program.load(splash_code, add_to_recents=False, switch_to_mode_auto=False))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION

`VCPMainWindow@loadSplashGcode` is use at program startup to load an initial program file
set via either `[DISAPLY]OPEN_FILE` or as per `_Info@getOpenFile` `TOP_DIR, 'sim/example_gcode/qtpyvcp.ngc'` or `'~/linuxcnc/nc_files/.qtpyvcp/qtpyvcp.ngc'`


`program_actions@load` bu default switch's the machine to AUTO, this is fine for machine with simple kinematic that start up in `world` mode but for more complex machine like a dual gantry (XYYZ) that starts up in `joint` mode until homed this throws an error