### PR TITLE
Add support for air blast, vacuum & both for M7 & M8.

### DIFF
--- a/src/qtpyvcp/ops/base_op.py
+++ b/src/qtpyvcp/ops/base_op.py
@@ -35,6 +35,13 @@ class BaseGenerator(object):
             gcode.append('M7')
         elif self.coolant.lower() == 'flood':
             gcode.append('M8')
+        elif self.coolant.lower() == 'air blast':
+            gcode.append('M7')
+        elif self.coolant.lower() == 'vacuum':
+            gcode.append('M8')
+        elif self.coolant.lower() == 'both':
+            gcode.append('M7')
+            gcode.append('M8')
 
         return gcode
 


### PR DESCRIPTION
For conversational operations, base_op.py  compares the text values from the pulldown to know if to use M7 or M8.  As a result, if you call them something else such as air blast, vacuum, or if you want to toggle both, then it wouldn't work.  Added these options in.  Not sure if it's possible to do this a different way so that other people can change the values, I.E. instead of vacuum, they could use dust hood or something.  