### PR TITLE
Use Qt built-in icons for notification widget messages

### DIFF
--- a/src/qtpyvcp/widgets/display_widgets/notification_widget.py
+++ b/src/qtpyvcp/widgets/display_widgets/notification_widget.py
@@ -17,8 +17,8 @@
 #   along with QtPyVCP.  If not, see <http://www.gnu.org/licenses/>.
 
 from qtpy.QtCore import Qt, QSortFilterProxyModel, QRegExp
-from qtpy.QtGui import QStandardItemModel, QStandardItem, QIcon
-from qtpy.QtWidgets import QVBoxLayout, QStackedWidget, QLabel, QListView, QHBoxLayout, QWidget, QPushButton
+from qtpy.QtGui import QStandardItemModel, QStandardItem
+from qtpy.QtWidgets import QVBoxLayout, QLabel, QListView, QHBoxLayout, QWidget, QPushButton, QStyle
 
 from qtpyvcp.widgets import VCPWidget
 from qtpyvcp.plugins import getPlugin
@@ -111,7 +111,7 @@ class NotificationWidget(QWidget, VCPWidget):
         msg = 'INFO:\nTIME {}\n  {}'.format(current_time, message)
         notification_item = QStandardItem()
         notification_item.setText(msg)
-        notification_item.setIcon(QIcon.fromTheme('dialog-information'))
+        notification_item.setIcon(self.style().standardIcon(QStyle.SP_MessageBoxInformation))
         notification_item.setEditable(False)
         self.all_notification_model.appendRow(notification_item)
 
@@ -124,7 +124,7 @@ class NotificationWidget(QWidget, VCPWidget):
         msg = 'WARNING:\nTIME {}\n  {}'.format(current_time, message)
         notification_item = QStandardItem()
         notification_item.setText(msg)
-        notification_item.setIcon(QIcon.fromTheme('dialog-warning'))
+        notification_item.setIcon(self.style().standardIcon(QStyle.SP_MessageBoxWarning))
         notification_item.setEditable(False)
         self.all_notification_model.appendRow(notification_item)
 
@@ -137,7 +137,7 @@ class NotificationWidget(QWidget, VCPWidget):
         msg = 'ERROR:\nTIME {}\n  {}'.format(current_time, message)
         notification_item = QStandardItem()
         notification_item.setText(msg)
-        notification_item.setIcon(QIcon.fromTheme('dialog-error'))
+        notification_item.setIcon(self.style().standardIcon(QStyle.SP_MessageBoxCritical))
         notification_item.setEditable(False)
         self.all_notification_model.appendRow(notification_item)
 
@@ -150,7 +150,7 @@ class NotificationWidget(QWidget, VCPWidget):
         msg = 'DEBUG\nTIME {}\n  {}'.format(current_time, message)
         notification_item = QStandardItem()
         notification_item.setText(msg)
-        notification_item.setIcon(QIcon.fromTheme('dialog-question'))
+        notification_item.setIcon(self.style().standardIcon(QStyle.SP_MessageBoxQuestion))
         notification_item.setEditable(False)
         self.all_notification_model.appendRow(notification_item)
 


### PR DESCRIPTION
Icons for messages do
not appear in the
notifications widget
if the icons do not
exist. This error
is present when using
the linuxcnc debian
image.
This commit changes
the icons to the
built-in Qt icons
instead.

This code will need to be tested to verify that it works as expected.