### PR TITLE
Fix timing issue with active_wc_index

### DIFF
--- a/src/qtpyvcp/widgets/display_widgets/vtk_backplot/vtk_backplot.py
+++ b/src/qtpyvcp/widgets/display_widgets/vtk_backplot/vtk_backplot.py
@@ -1175,7 +1175,7 @@ class VTKBackPlot(QVTKRenderWindowInteractor, VCPWidget, BaseBackPlot):
             self.setViewZ2()
         elif view == 'P':
             self.setViewP()
-       elif view == 'M':
+        elif view == 'M':
             self.setViewMachine()
 
     @Slot()

--- a/src/qtpyvcp/widgets/display_widgets/vtk_backplot/vtk_backplot.py
+++ b/src/qtpyvcp/widgets/display_widgets/vtk_backplot/vtk_backplot.py
@@ -1175,11 +1175,16 @@ class VTKBackPlot(QVTKRenderWindowInteractor, VCPWidget, BaseBackPlot):
             self.setViewZ2()
         elif view == 'P':
             self.setViewP()
+       elif view == 'M':
+            self.setViewMachine()
 
     @Slot()
     def setViewP(self):
         self.active_view = 'P'
         
+        if not (0 <= self.active_wcs_index < len(self.wcs_offsets)):
+            self.active_wcs_index = 0
+
         position = self.wcs_offsets[self.active_wcs_index]
         
         self.camera.SetPosition(self.position_mult, -self.position_mult, self.position_mult)
@@ -1191,6 +1196,9 @@ class VTKBackPlot(QVTKRenderWindowInteractor, VCPWidget, BaseBackPlot):
     def setViewX(self):
         self.active_view = 'X'
         
+        if not (0 <= self.active_wcs_index < len(self.wcs_offsets)):
+            self.active_wcs_index = 0
+
         position = self.wcs_offsets[self.active_wcs_index]
         ot_columns_index = self.offsetTableColumnsIndex
         
@@ -1224,6 +1232,9 @@ class VTKBackPlot(QVTKRenderWindowInteractor, VCPWidget, BaseBackPlot):
     def setViewXZ(self):
         self.active_view = 'XZ'
         
+        if not (0 <= self.active_wcs_index < len(self.wcs_offsets)):
+            self.active_wcs_index = 0
+
         position = self.wcs_offsets[self.active_wcs_index]
         ot_columns_index = self.offsetTableColumnsIndex
         
@@ -1256,6 +1267,9 @@ class VTKBackPlot(QVTKRenderWindowInteractor, VCPWidget, BaseBackPlot):
     def setViewXZ2(self):
         self.active_view = 'XZ2'
         
+        if not (0 <= self.active_wcs_index < len(self.wcs_offsets)):
+            self.active_wcs_index = 0
+
         position = self.wcs_offsets[self.active_wcs_index]
         ot_columns_index = self.offsetTableColumnsIndex
         
@@ -1288,6 +1302,9 @@ class VTKBackPlot(QVTKRenderWindowInteractor, VCPWidget, BaseBackPlot):
     def setViewY(self):
         self.active_view = 'Y'
         
+        if not (0 <= self.active_wcs_index < len(self.wcs_offsets)):
+            self.active_wcs_index = 0
+
         position = self.wcs_offsets[self.active_wcs_index]
         ot_columns_index = self.offsetTableColumnsIndex
         
@@ -1320,6 +1337,9 @@ class VTKBackPlot(QVTKRenderWindowInteractor, VCPWidget, BaseBackPlot):
     def setViewZ(self):
         self.active_view = 'Z'
         
+        if not (0 <= self.active_wcs_index < len(self.wcs_offsets)):
+            self.active_wcs_index = 0
+
         position = self.wcs_offsets[self.active_wcs_index]
         ot_columns_index = self.offsetTableColumnsIndex
         
@@ -1352,6 +1372,9 @@ class VTKBackPlot(QVTKRenderWindowInteractor, VCPWidget, BaseBackPlot):
     def setViewZ2(self):
         self.active_view = 'Z2'
         
+        if not (0 <= self.active_wcs_index < len(self.wcs_offsets)):
+            self.active_wcs_index = 0
+
         position = self.wcs_offsets[self.active_wcs_index]
         ot_columns_index = self.offsetTableColumnsIndex
         
@@ -1382,6 +1405,8 @@ class VTKBackPlot(QVTKRenderWindowInteractor, VCPWidget, BaseBackPlot):
 
     @Slot()
     def setViewMachine(self):
+        self.active_view = 'M'
+
         LOG.debug('-----setViewMachine')
         machine_bounds = self.machine_actor.GetBounds()
         LOG.debug('-----machine_bounds: {}'.format(machine_bounds))

--- a/src/qtpyvcp/widgets/display_widgets/vtk_backplot/vtk_backplot.py
+++ b/src/qtpyvcp/widgets/display_widgets/vtk_backplot/vtk_backplot.py
@@ -168,6 +168,7 @@ class VTKBackPlot(QVTKRenderWindowInteractor, VCPWidget, BaseBackPlot):
         view_default_setting = getSetting("backplot.view").value
         view_options_setting = getSetting("backplot.view").enum_options
         view_options = list()
+        self.machine_ext_scale = getSetting("backplot.machine-ext-scale").value
             
         for option in view_options_setting:
             view_options.append(option.split(':')[0])
@@ -1438,7 +1439,7 @@ class VTKBackPlot(QVTKRenderWindowInteractor, VCPWidget, BaseBackPlot):
         LOG.debug('-----z_dist: {}'.format(z_dist))
 
         scale = max(x_dist, y_dist, z_dist)
-        new_scale = scale * 0.65
+        new_scale = scale * self.machine_ext_scale
         
         self.camera.SetParallelScale(new_scale)
         self.camera.SetViewUp(0, 0, 1)
@@ -1530,6 +1531,10 @@ class VTKBackPlot(QVTKRenderWindowInteractor, VCPWidget, BaseBackPlot):
     @Slot()
     def setViewPath(self):
         LOG.debug('-----setViewPath')
+
+        if not (0 <= self.active_wcs_index < len(self.wcs_offsets)):
+            self.active_wcs_index = 0
+
         position = self.wcs_offsets[self.active_wcs_index]
         self.camera.SetPosition(position[0] + self.position_mult,
                                 -(position[1] + self.position_mult),

--- a/src/qtpyvcp/yaml_lib/default_config.yml
+++ b/src/qtpyvcp/yaml_lib/default_config.yml
@@ -178,6 +178,9 @@ settings:
     default_value: 0
     options: ["X: Front View", "XZ: Lathe View", "XZ2: Lathe View", "Y: Front View", "Z: Top View", "Z2: Bottom View", "P: Isometric"]
 
+  backplot.machine-ext-scale:
+    default_value: 0.65
+
   backplot.multitool-colors:
     default_value: false
  


### PR DESCRIPTION
active_wc_index can sometimes be set to -1. I think this is a timing issue, as it dervies this value from _status.stat.g5x_index In getActiveWcsIndex() method, it returns self._status.stat.g5x_index -1 If _status.stat.g5x_index is 0 because it's not been initialized from linuxcnc yet, then it will return -1, which breaks the views.

Add Machine EXT View for default / persistant view optin in yaml file.

** ToDo ** Add avility to set BASE scale value for setViewMachine and/or maybe default zoom level