### PR TITLE
Implement 'add' in vtk_backplot.py

### DIFF
--- a/src/qtpyvcp/widgets/display_widgets/vtk_backplot/vtk_backplot.py
+++ b/src/qtpyvcp/widgets/display_widgets/vtk_backplot/vtk_backplot.py
@@ -1510,7 +1510,7 @@ class VTKBackPlot(QVTKRenderWindowInteractor, VCPWidget, BaseBackPlot):
         LOG.debug("---------update_g92_offset: {}".format(g92_offset))
         if self._datasource.isModeMdi() or self._datasource.isModeAuto():
             self.g92_offset = g92_offset
-
+            add = lambda *x: sum(x)
             path_offset = list(map(add, self.g92_offset, self.original_g92_offset))
             LOG.debug("---------path_offset: {}".format(path_offset))
 


### PR DESCRIPTION
Fixes error caused by undefined `add` function when using vtk_backplot with g92 offset.