### PR TITLE
fix bug: file created from scratch not loaded into linuxcnc on save

### DIFF
--- a/src/qtpyvcp/widgets/input_widgets/gcode_text_edit.py
+++ b/src/qtpyvcp/widgets/input_widgets/gcode_text_edit.py
@@ -622,7 +622,10 @@ class GcodeTextEdit(QPlainTextEdit):
             default_path = current_file_name
 
         save_file = self.save_as_dialog(default_path)
-        self.saveFile(save_file)
+        if save_file:
+            self.saveFile(save_file)
+            # Load the newly saved file into LinuxCNC so STATUS.file is updated
+            program_actions.load(save_file)
 
     def keyPressEvent(self, event):
         # keep the cursor centered


### PR DESCRIPTION
Previously creating a file from scratch did not load it into linuxcnc. 
Had to be read in via the filemanager instead.
