### PR TITLE
Load Python VCP files with importlib

### DIFF
--- a/audit_reports/running_notes.rst
+++ b/audit_reports/running_notes.rst
@@ -40,6 +40,32 @@ Files
    - src/qtpyvcp/path/to/file.py
 
 
+2026-05-25
+----------
+
+Area
+   App Python VCP file loader
+
+Summary
+   Restored loading of `.py` VCP files on Python versions where `imp` has been
+   removed.
+
+Changes
+   - Replaced the removed `imp.load_source()` path with
+     `importlib.util.spec_from_file_location()` and `module_from_spec()`.
+   - Kept the loaded module registered as `python_vcp` so existing attribute
+     access and class discovery continue to use the historical module name.
+
+Validation
+   - Static validation only: `git diff --check HEAD~1..HEAD`.
+   - Targeted search confirmed `application.py` no longer uses `load_source`.
+   - Not run locally: QtPyVCP/LinuxCNC runtime and example VCPs.
+
+Files
+   - src/qtpyvcp/app/application.py
+   - audit_reports/running_notes.rst
+
+
 2026-02-20
 ----------
 

--- a/src/qtpyvcp/app/application.py
+++ b/src/qtpyvcp/app/application.py
@@ -4,7 +4,7 @@ Contains the VCPApplication class with core function and VCP loading logic.
 """
 import os
 import sys
-import importlib as imp
+import importlib.util
 import inspect
 from pkg_resources import iter_entry_points
 
@@ -154,8 +154,14 @@ class VCPApplication(QApplication):
         module_dir = os.path.dirname(os.path.abspath(pyfile))
         sys.path.append(module_dir)
 
-        # Load the module. It's attributes can be accessed via `python_vcp.attr`
-        module = imp.load_source('python_vcp', pyfile)
+        # Load the module. Its attributes can be accessed via `python_vcp.attr`
+        module_name = 'python_vcp'
+        spec = importlib.util.spec_from_file_location(module_name, pyfile)
+        if spec is None or spec.loader is None:
+            raise ImportError("Could not load Python VCP file: {}".format(pyfile))
+        module = importlib.util.module_from_spec(spec)
+        sys.modules[module_name] = module
+        spec.loader.exec_module(module)
 
         classes = [obj for name, obj in inspect.getmembers(module)
                    if inspect.isclass(obj)


### PR DESCRIPTION
## Summary
- replace the remaining `imp.load_source()`-style Python VCP loader path with `importlib.util.spec_from_file_location()` / `module_from_spec()`
- keep the loaded module registered as `python_vcp` so the existing class discovery path continues to use the historical module name
- add a running-notes entry for the app loader change

## Validation
- `git diff --check HEAD~1..HEAD`
- `rg -n "\bimp\b|load_source|spec_from_file_location|module_from_spec|python_vcp" src/qtpyvcp/app/application.py audit_reports/running_notes.rst`
- Not run locally: QtPyVCP/LinuxCNC runtime, example VCPs, video tests, docs build.

Closes #158
